### PR TITLE
Add and update fields

### DIFF
--- a/app/content/content.yaml
+++ b/app/content/content.yaml
@@ -113,3 +113,257 @@ request_form:
       label: Town or city
       messages:
         required: Your town or city is required
+    requester_county:
+      label: County (optional)
+    requester_postcode:
+      label: Postcode or Zip code (optional)
+    requester_country:
+      label: Country
+      countries:
+        - United Kingdom
+        - Afghanistan
+        - Aland Islands
+        - Albania
+        - Algeria
+        - American Samoa
+        - Andorra
+        - Angola
+        - Anguilla
+        - Antarctica
+        - Antigua and Barbuda
+        - Argentina
+        - Armenia
+        - Aruba
+        - Australia
+        - Austria
+        - Azerbaijan
+        - BFPO
+        - Bahamas
+        - Bahrain
+        - Bangladesh
+        - Barbados
+        - Belarus
+        - Belgium
+        - Belize
+        - Benin
+        - Bermuda
+        - Bhutan
+        - Bolivia
+        - Bosnia and Herzegovina
+        - Botswana
+        - Bouvet Island
+        - Brazil
+        - British Indian Ocean Territory
+        - British Virgin Islands
+        - Brunei Darussalam
+        - Bulgaria
+        - Burkina Faso
+        - Burundi
+        - Cambodia
+        - Cameroon
+        - Canada
+        - Cape Verde
+        - Cayman Islands
+        - Central African Republic
+        - Chad
+        - Channel Islands
+        - Chile
+        - China
+        - Christmas Island
+        - Cocos (Keeling) Islands
+        - Colombia
+        - Comoros
+        - Congo
+        - Cook Islands
+        - Costa Rica
+        - Cote D'Ivoire
+        - Croatia
+        - Cuba
+        - Cyprus
+        - Czech Republic
+        - Democratic People's Republic of Korea
+        - Denmark
+        - Djibouti
+        - Dominica
+        - Dominican Republic
+        - Ecuador
+        - Egypt
+        - El Salvador
+        - Equatorial Guinea
+        - Eritrea
+        - Estonia
+        - Ethiopia
+        - Falkland Islands
+        - Faroe Islands
+        - Federated States of Micronesia
+        - Fiji
+        - Finland
+        - France
+        - French Guiana
+        - French Polynesia
+        - French Southern Territories
+        - Gabon
+        - Gambia
+        - Georgia
+        - Germany
+        - Ghana
+        - Gibraltar
+        - Greece
+        - Greenland
+        - Grenada
+        - Guadeloupe
+        - Guam
+        - Guatemala
+        - Guinea
+        - Guinea-Bissau
+        - Guyana
+        - Haiti
+        - Heard Island and McDonald Islands
+        - Holy See (Vatican City State)
+        - Honduras
+        - Hong Kong
+        - Hungary
+        - Iceland
+        - India
+        - Indonesia
+        - Iraq
+        - Ireland
+        - Islamic Republic of Iran
+        - Isle Of Man
+        - Israel
+        - Italy
+        - Jamaica
+        - Japan
+        - Jordan
+        - Kazakhstan
+        - Kenya
+        - Kiribati
+        - Kuwait
+        - Kyrgyzstan
+        - Lao Peoples's Democratic Republic
+        - Latvia
+        - Lebanon
+        - Lesotho
+        - Liberia
+        - Libyan Arab Jamahiriya
+        - Liechtenstein
+        - Lithuania
+        - Luxembourg
+        - Macao
+        - Madagascar
+        - Malawi
+        - Malaysia
+        - Maldives
+        - Mali
+        - Malta
+        - Marshall Islands
+        - Martinique
+        - Mauritania
+        - Mauritius
+        - Mayotte
+        - Mexico
+        - Monaco
+        - Mongolia
+        - Montenegro
+        - Montserrat
+        - Morocco
+        - Mozambique
+        - Myanmar
+        - Namibia
+        - Nauru
+        - Nepal
+        - Netherlands Antilles
+        - Netherlands
+        - New Caledonia
+        - New Zealand
+        - Nicaragua
+        - Niger
+        - Nigeria
+        - Niue
+        - Norfolk Island
+        - Northern Mariana Islands
+        - Norway
+        - Oman
+        - Pakistan
+        - Palau
+        - Palestinian Occupied Territories
+        - Panama
+        - Papua New Guinea
+        - Paraguay
+        - Peru
+        - Philippines
+        - Pitcairn
+        - Poland
+        - Portugal
+        - Puerto Rico
+        - Qatar
+        - Republic of Korea
+        - Republic of Moldova
+        - Reunion
+        - Romania
+        - Russian Federation
+        - Rwanda
+        - Saint Helena
+        - Saint Kitts and Nevis
+        - Saint Lucia
+        - Saint Pierre and Miquelon
+        - Saint Vincent and the Grenadines
+        - Samoa
+        - San Marino
+        - Sao Tome and Principe
+        - Saudi Arabia
+        - Senegal
+        - Serbia
+        - Seychelles
+        - Sierra Leone
+        - Singapore
+        - Slovakia
+        - Slovenia
+        - Solomon Islands
+        - Somalia
+        - South Africa
+        - South Georgia and the South Sandwich Islands
+        - Spain
+        - Sri Lanka
+        - Sudan
+        - Suriname
+        - Svalbard and Jan Mayen
+        - Swaziland
+        - Sweden
+        - Switzerland
+        - Syrian Arab Republic
+        - Taiwan
+        - Tajikistan
+        - Thailand
+        - The Democratic Republic of the Congo
+        - The former Yugoslav Republic of Macedonia
+        - Timor-Leste
+        - Togo
+        - Tokelau
+        - Tonga
+        - Trinidad and Tobago
+        - Tunisia
+        - Turkey
+        - Turkmenistan
+        - Turks and Caicos Islands
+        - Tuvalu
+        - Uganda
+        - Ukraine
+        - United Arab Emirates
+        - United Republic of Tanzania
+        - United States Minor Outlying Islands
+        - United States
+        - Uruguay
+        - Uzbekistan
+        - Vanuatu
+        - Venezuela
+        - Viet Nam
+        - Virgin Islands
+        - U.S.
+        - Wallis and Futuna
+        - Western Sahara
+        - Yemen
+        - Zambia
+        - Zimbabwe
+      messages:
+        required: Country is required

--- a/app/main/forms/request_a_service_record.py
+++ b/app/main/forms/request_a_service_record.py
@@ -5,6 +5,7 @@ from tna_frontend_jinja.wtforms import (
     TnaDateField,
     TnaDroppableFileInputWidget,
     TnaRadiosWidget,
+    TnaSelectWidget,
     TnaSubmitWidget,
     TnaTextareaWidget,
     TnaTextInputWidget,
@@ -14,6 +15,7 @@ from wtforms import (
     EmailField,
     FileField,
     RadioField,
+    SelectField,
     StringField,
     SubmitField,
     TextAreaField,
@@ -260,9 +262,33 @@ class RequestAServiceRecord(FlaskForm):
     )
 
     requester_county = StringField(
-        "County (optional)",
+        content["request_form"]["fields"]["requester_county"]["label"],
         widget=TnaTextInputWidget(),
         validators=[],
+    )
+
+    requester_postcode = StringField(
+        content["request_form"]["fields"]["requester_postcode"]["label"],
+        widget=TnaTextInputWidget(),
+        validators=[],
+    )
+
+    requester_country = SelectField(
+        content["request_form"]["fields"]["requester_country"]["label"],
+        choices=[
+            (item, item)
+            for item in content["request_form"]["fields"]["requester_country"][
+                "countries"
+            ]
+        ],
+        widget=TnaSelectWidget(),
+        validators=[
+            InputRequired(
+                message=content["request_form"]["fields"]["requester_country"][
+                    "messages"
+                ]["required"]
+            )
+        ],
     )
 
     submit = SubmitField("Continue", widget=TnaSubmitWidget())

--- a/app/templates/main/request-a-service-record.html
+++ b/app/templates/main/request-a-service-record.html
@@ -59,6 +59,9 @@
           {{ form.requester_address1(params={'headingLevel':3, 'size':'m', 'autocomplete':'address-line1'}) }}
           {{ form.requester_address2(params={'headingLevel':3, 'size':'m', 'autocomplete':'address-line2'}) }}
           {{ form.requester_town_city(params={'headingLevel':3, 'size':'m', 'autocomplete':'address-level1'}) }}
+          {{ form.requester_county(params={'headingLevel':3, 'size':'m'}) }}
+          {{ form.requester_postcode(params={'headingLevel':3, 'size':'m', 'autocomplete':'postal-code'}) }}
+          {{ form.requester_country(params={'headingLevel':3, 'size':'m', 'autocomplete':'country'}) }}
 
           <div class="tna-button-group">
             {{ form.submit }}


### PR DESCRIPTION
## Summary of change

This commit adds two new fields (country and postcode) using the autocomplete tokens from the WHATWG spec[^1].

For the time-being all form options are included in `content.yaml`, so I've done the same here for country. My sense is that a good future refactor will be to move these out of the content - but it works for now.

I've tried to make the code a bit easier to read by introducing a `prepare_country_options` helper. I haven't applied this helper to other fields because countries appear to be unique in that the value is the same as the text presented to the user.

[^1]: https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofill-expectation-mantle