### PR TITLE
Add content helpers

### DIFF
--- a/app/content/content.yaml
+++ b/app/content/content.yaml
@@ -119,6 +119,7 @@ request_form:
       label: Postcode or Zip code (optional)
     requester_country:
       label: Country
+      prompt_to_select: Select a country
       countries:
         - United Kingdom
         - Afghanistan

--- a/app/lib/content.py
+++ b/app/lib/content.py
@@ -23,3 +23,27 @@ def get_field_content(content, field_name, content_key=None):
     except KeyError as e:
         print(f"Error accessing {field_name}: {e}")
         return f"'{field_name}' not found in content."
+
+
+def prepare_country_options(content):
+    try:
+        prompt = get_field_content(content, "requester_country", "prompt_to_select")
+        countries = get_field_content(content, "requester_country", "countries")
+
+        if prompt is None:
+            raise TypeError("Country prompt is missing from content")
+
+        if countries is None:
+            raise TypeError("Countries list is missing from content")
+
+        if not isinstance(prompt, str):
+            raise TypeError("Country prompt must be a string")
+
+        if not isinstance(countries, list):
+            raise TypeError("Countries must be a list")
+
+        result = [("", prompt)] + [(country, country) for country in countries]
+    except (KeyError, TypeError) as e:
+        print(f"Error accessing requester country choices: {e}")
+        result = []
+    return result

--- a/app/lib/content.py
+++ b/app/lib/content.py
@@ -11,3 +11,15 @@ def load_content(file_path="app/content/content.yaml"):
     except yaml.YAMLError as e:
         print(f"Error parsing YAML file: {e}")
         return {}
+
+
+def get_field_content(content, field_name, content_key=None):
+    try:
+        field_content = content["request_form"]["fields"][field_name]
+
+        if content_key:
+            return field_content.get(content_key)
+        return field_content
+    except KeyError as e:
+        print(f"Error accessing {field_name}: {e}")
+        return f"'{field_name}' not found in content."

--- a/app/main/forms/request_a_service_record.py
+++ b/app/main/forms/request_a_service_record.py
@@ -1,4 +1,4 @@
-from app.lib.content import load_content
+from app.lib.content import load_content, get_field_content, prepare_country_options
 from flask_wtf import FlaskForm
 from flask_wtf.file import FileAllowed, FileSize
 from tna_frontend_jinja.wtforms import (
@@ -27,266 +27,225 @@ class RequestAServiceRecord(FlaskForm):
     content = load_content()
 
     forenames = StringField(
-        content["request_form"]["fields"]["forenames"]["label"],
+        get_field_content(content, "forenames", "label"),
         widget=TnaTextInputWidget(),
         validators=[
             InputRequired(
-                message=content["request_form"]["fields"]["forenames"]["messages"][
-                    "required"
-                ]
+                message=get_field_content(content, "forenames", "messages")["required"]
             ),
         ],
     )
 
     lastname = StringField(
-        content["request_form"]["fields"]["last_name"]["label"],
+        get_field_content(content, "last_name", "label"),
         widget=TnaTextInputWidget(),
         validators=[
             InputRequired(
-                message=content["request_form"]["fields"]["last_name"]["messages"][
-                    "required"
-                ]
+                message=get_field_content(content, "last_name", "messages")["required"]
             ),
         ],
     )
 
     other_last_names = StringField(
-        content["request_form"]["fields"]["other_last_names"]["label"],
+        get_field_content(content, "other_last_names", "label"),
         widget=TnaTextInputWidget(),
         validators=[],
     )
 
     date_of_birth = TnaDateField(
-        content["request_form"]["fields"]["dob"]["label"],
-        description=content["request_form"]["fields"]["dob"]["description"],
+        get_field_content(content, "dob", "label"),
+        description=get_field_content(content, "dob", "description"),
         validators=[
             InputRequired(
-                message=content["request_form"]["fields"]["dob"]["messages"]["required"]
+                message=get_field_content(content, "dob", "messages")["required"]
             ),
             tna_frontend_validators.PastDate(
-                message=content["request_form"]["fields"]["dob"]["messages"][
-                    "past_date"
-                ]
+                message=get_field_content(content, "dob", "messages")["past_date"]
             ),
         ],
     )
 
     place_of_birth = StringField(
-        content["request_form"]["fields"]["place_of_birth"]["label"],
+        get_field_content(content, "place_of_birth", "label"),
         widget=TnaTextInputWidget(),
         validators=[],
     )
 
     date_of_death = TnaDateField(
-        content["request_form"]["fields"]["date_of_death"]["label"],
-        description=content["request_form"]["fields"]["date_of_death"]["description"],
+        get_field_content(content, "date_of_death", "label"),
+        description=get_field_content(content, "date_of_death", "description"),
         validators=[
             tna_frontend_validators.PastDate(
-                message=content["request_form"]["fields"]["date_of_death"]["messages"][
-                    "past_date"
-                ],
+                message=get_field_content(content, "date_of_death", "messages")["past_date"],
                 include_today=True
             ),
         ],
     )
 
     service_number = StringField(
-        content["request_form"]["fields"]["service_number"]["label"],
+        get_field_content(content, "service_number", "label"),
         widget=TnaTextInputWidget(),
         validators=[],
     )
 
     regiment = StringField(
-        content["request_form"]["fields"]["regiment"]["label"],
+        get_field_content(content, "regiment", "label"),
         widget=TnaTextInputWidget(),
         validators=[],
     )
 
     service_branch = RadioField(
-        content["request_form"]["fields"]["service_branch"]["label"],
+        get_field_content(content, "service_branch", "label"),
         choices=[
             (key, value)
-            for key, value in content["request_form"]["fields"]["service_branch"][
-                "options"
-            ].items()
+            for key, value in get_field_content(content, "service_branch", "options").items()
         ],
         validators=[
             InputRequired(
-                message=content["request_form"]["fields"]["service_branch"]["messages"][
-                    "required"
-                ]
+                message=get_field_content(content, "service_branch", "messages")["required"]
             )
         ],
         widget=TnaRadiosWidget(),
     )
 
     mod_reference = StringField(
-        content["request_form"]["fields"]["mod_reference"]["label"],
-        description=content["request_form"]["fields"]["mod_reference"]["description"],
+        get_field_content(content, "mod_reference", "label"),
+        description=get_field_content(content, "mod_reference", "description"),
         widget=TnaTextInputWidget(),
         validators=[],
     )
 
     additional_information = TextAreaField(
-        content["request_form"]["fields"]["additional_information"]["label"],
-        description=content["request_form"]["fields"]["additional_information"][
-            "description"
-        ],
+        get_field_content(content, "additional_information", "label"),
+        description=get_field_content(content, "additional_information", "description"),
         validators=[],
         widget=TnaTextareaWidget(),
     )
 
     evidence_of_death = FileField(
-        content["request_form"]["fields"]["evidence_of_death"]["label"],
+        get_field_content(content, "evidence_of_death", "label"),
         validators=[
             FileAllowed(
                 upload_set=["jpg", "png", "gif"],
-                message=content["request_form"]["fields"]["evidence_of_death"][
-                    "messages"
-                ]["file_allowed"],
+                message=get_field_content(content, "evidence_of_death", "messages")["file_allowed"],
             ),
             FileSize(
                 max_size=20 * 1024 * 1024,
-                message=content["request_form"]["fields"]["evidence_of_death"][
-                    "messages"
-                ]["file_size"],
+                message=get_field_content(content, "evidence_of_death", "messages")["file_size"],
             ),
         ],
         widget=TnaDroppableFileInputWidget(),
     )
 
     died_in_service = RadioField(
-        content["request_form"]["fields"]["died_in_service"]["label"],
+        get_field_content(content, "died_in_service", "label"),
         choices=[("yes", "Yes"), ("no", "No"), ("unknown", "Unknown")],
         validators=[
             InputRequired(
-                message=content["request_form"]["fields"]["died_in_service"][
-                    "messages"
-                ]["required"]
+                message=get_field_content(content, "died_in_service", "messages")["required"]
             )
         ],
         widget=TnaRadiosWidget(),
     )
 
     case_reference_number = StringField(
-        content["request_form"]["fields"]["case_reference_number"]["label"],
-        description=content["request_form"]["fields"]["case_reference_number"][
-            "description"
-        ],
+        get_field_content(content, "case_reference_number", "label"),
+        description=get_field_content(content, "case_reference_number", "description"),
         widget=TnaTextInputWidget(),
         validators=[],
     )
 
     requester_title = StringField(
-        content["request_form"]["fields"]["requester_title"]["label"],
+        get_field_content(content, "requester_title", "label"),
         widget=TnaTextInputWidget(),
         validators=[],
     )
 
     requester_first_name = StringField(
-        content["request_form"]["fields"]["requester_first_name"]["label"],
+        get_field_content(content, "requester_first_name", "label"),
         widget=TnaTextInputWidget(),
         validators=[],
     )
 
     requester_last_name = StringField(
-        content["request_form"]["fields"]["requester_last_name"]["label"],
+        get_field_content(content, "requester_last_name", "label"),
         widget=TnaTextInputWidget(),
         validators=[
             InputRequired(
-                message=content["request_form"]["fields"]["requester_last_name"][
-                    "messages"
-                ]["required"]
+                message=get_field_content(content, "requester_last_name", "messages")["required"]
             )
         ],
     )
 
     requester_contact_preference = RadioField(
-        content["request_form"]["fields"]["contact_preferences"]["label"],
+        get_field_content(content, "contact_preferences", "label"),
         choices=[("email", "Email"), ("post", "Post")],
         validators=[
             InputRequired(
-                message=content["request_form"]["fields"]["contact_preferences"][
-                    "messages"
-                ]["required"]
+                message=get_field_content(content, "contact_preferences", "messages")["required"]
             )
         ],
         widget=TnaRadiosWidget(),
     )
 
     requester_email = EmailField(
-        content["request_form"]["fields"]["requester_email"]["label"],
+        get_field_content(content, "requester_email", "label"),
         validators=[
             InputRequired(
-                message=content["request_form"]["fields"]["requester_email"][
-                    "messages"
-                ]["required"]
+                message=get_field_content(content, "requester_email", "messages")["required"]
             ),
             Email(
-                message=content["request_form"]["fields"]["requester_email"][
-                    "messages"
-                ]["address_format"]
+                message=get_field_content(content, "requester_email", "messages")["address_format"]
             ),
         ],
         widget=TnaTextInputWidget(),
     )
 
     requester_address1 = StringField(
-        content["request_form"]["fields"]["requester_address_line_1"]["label"],
+        get_field_content(content, "requester_address_line_1", "label"),
         widget=TnaTextInputWidget(),
         validators=[
             InputRequired(
-                message=content["request_form"]["fields"]["requester_address_line_1"][
-                    "messages"
-                ]["required"]
+                message=get_field_content(content, "requester_address_line_1", "messages")["required"]
             )
         ],
     )
 
     requester_address2 = StringField(
-        content["request_form"]["fields"]["requester_address_line_2"]["label"],
+        get_field_content(content, "requester_address_line_2", "label"),
         widget=TnaTextInputWidget(),
         validators=[],
     )
 
     requester_town_city = StringField(
-        content["request_form"]["fields"]["requester_town_city"]["label"],
+        get_field_content(content, "requester_town_city", "label"),
         widget=TnaTextInputWidget(),
         validators=[
             InputRequired(
-                message=content["request_form"]["fields"]["requester_town_city"][
-                    "messages"
-                ]["required"]
+                message=get_field_content(content, "requester_town_city", "messages")["required"]
             )
         ],
     )
 
     requester_county = StringField(
-        content["request_form"]["fields"]["requester_county"]["label"],
+        get_field_content(content, "requester_county", "label"),
         widget=TnaTextInputWidget(),
         validators=[],
     )
 
     requester_postcode = StringField(
-        content["request_form"]["fields"]["requester_postcode"]["label"],
+        get_field_content(content, "requester_postcode", "label"),
         widget=TnaTextInputWidget(),
         validators=[],
     )
 
     requester_country = SelectField(
         content["request_form"]["fields"]["requester_country"]["label"],
-        choices=[
-            (item, item)
-            for item in content["request_form"]["fields"]["requester_country"][
-                "countries"
-            ]
-        ],
+        get_field_content(content, "requester_country", "label"),
         widget=TnaSelectWidget(),
         validators=[
             InputRequired(
-                message=content["request_form"]["fields"]["requester_country"][
-                    "messages"
-                ]["required"]
+                message=get_field_content(content, "requester_country", "messages")["required"]
             )
         ],
     )

--- a/app/main/forms/request_a_service_record.py
+++ b/app/main/forms/request_a_service_record.py
@@ -240,8 +240,8 @@ class RequestAServiceRecord(FlaskForm):
     )
 
     requester_country = SelectField(
-        content["request_form"]["fields"]["requester_country"]["label"],
         get_field_content(content, "requester_country", "label"),
+        choices=prepare_country_options(content),
         widget=TnaSelectWidget(),
         validators=[
             InputRequired(

--- a/test/content/test_get_field_content.py
+++ b/test/content/test_get_field_content.py
@@ -1,0 +1,72 @@
+import unittest
+from unittest.mock import patch
+from app.lib.content import get_field_content
+
+
+class TestGetFieldContent(unittest.TestCase):
+
+    def setUp(self):
+        # Test content with a structure matching content.yaml
+        self.test_content = {
+            "request_form": {
+                "fields": {
+                    "forenames": {
+                        "label": "Forenames (including middle names)",
+                        "messages": {
+                            "required": "The service person's first name is required"
+                        }
+                    },
+                    "last_name": {
+                        "label": "Last name",
+                        "messages": {
+                            "required": "The service person's last name is required"
+                        }
+                    },
+                    "requester_country": {
+                        "label": "Country",
+                        "prompt_to_select": "Select a country",
+                        "countries": ["United Kingdom", "United States", "Canada"]
+                    }
+                }
+            }
+        }
+
+    def test_get_full_field_content(self):
+        """Test retrieving the entire content for a field"""
+        expected = {
+            "label": "Forenames (including middle names)",
+            "messages": {
+                "required": "The service person's first name is required"
+            }
+        }
+        result = get_field_content(self.test_content, "forenames")
+        self.assertEqual(result, expected)
+
+    def test_get_specific_content_key(self):
+        """Test retrieving a specific content key from a field"""
+        result = get_field_content(self.test_content, "last_name", "label")
+        self.assertEqual(result, "Last name")
+
+    def test_get_nested_content_key(self):
+        """Test retrieving a nested content key from a field"""
+        result = get_field_content(self.test_content, "forenames", "messages")["required"]
+        self.assertEqual(result, "The service person's first name is required")
+
+    def test_missing_content_key(self):
+        """Test requesting a content key that doesn't exist"""
+        result = get_field_content(self.test_content, "forenames", "placeholder")
+        self.assertIsNone(result)
+
+    def test_missing_field(self):
+        """Test requesting a field that doesn't exist"""
+        result = get_field_content(self.test_content, "non_existent_field")
+        self.assertEqual(result, "'non_existent_field' not found in content.")
+
+    def test_complex_field_content(self):
+        """Test retrieving content from a field with complex data (list)"""
+        result = get_field_content(self.test_content, "requester_country", "countries")
+        self.assertEqual(result, ["United Kingdom", "United States", "Canada"])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/content/test_prepare_country_options.py
+++ b/test/content/test_prepare_country_options.py
@@ -1,0 +1,135 @@
+import unittest
+from unittest.mock import patch
+from app.lib.content import prepare_country_options
+
+
+class TestPrepareCountryOptions(unittest.TestCase):
+
+    def setUp(self):
+        # Test content with valid country data
+        self.test_content = {
+            "request_form": {
+                "fields": {
+                    "forenames": {
+                        "label": "Forenames (including middle names)",
+                        "messages": {
+                            "required": "The service person's first name is required"
+                        }
+                    },
+                    "last_name": {
+                        "label": "Last name",
+                        "messages": {
+                            "required": "The service person's last name is required"
+                        }
+                    },
+                    "requester_country": {
+                        "label": "Country",
+                        "prompt_to_select": "Please select a country",
+                        "countries": ["United Kingdom", "United States", "Canada"]
+                    }
+                }
+            }
+        }
+
+    def test_valid_country_options(self):
+        """Test with valid country data"""
+        expected = [
+            ("", "Please select a country"),
+            ("United Kingdom", "United Kingdom"),
+            ("United States", "United States"),
+            ("Canada", "Canada")
+        ]
+        result = prepare_country_options(self.test_content)
+        self.assertEqual(result, expected)
+
+    def test_missing_prompt(self):
+        """Test when prompt_to_select is missing"""
+        incomplete_content = {
+            "request_form": {
+                "fields": {
+                    "requester_country": {
+                        "label": "Country",
+                        "countries": ["United Kingdom", "United States", "Canada"]
+                    }
+                }
+            }
+        }
+        with patch('builtins.print') as mock_print:
+            result = prepare_country_options(incomplete_content)
+            mock_print.assert_called_once()
+            self.assertEqual(result, [])
+
+    def test_missing_country_field(self):
+        """Test when requester_country field is missing"""
+        content_without_country = {
+            "request_form": {
+                "fields": {
+                    "forenames": {
+                        "label": "Forenames (including middle names)"
+                    },
+                    "last_name": {
+                        "label": "Last name"
+                    }
+                }
+            }
+        }
+        with patch('builtins.print') as mock_print:
+            result = prepare_country_options(content_without_country)
+            # Check that print was called at least once with an error message
+            self.assertGreaterEqual(mock_print.call_count, 1)
+            self.assertEqual(result, [])
+
+    def test_missing_countries(self):
+        """Test when countries list is missing"""
+        incomplete_content = {
+            "request_form": {
+                "fields": {
+                    "requester_country": {
+                        "label": "Country",
+                        "prompt_to_select": "Please select a country"
+                    }
+                }
+            }
+        }
+        with patch('builtins.print') as mock_print:
+            result = prepare_country_options(incomplete_content)
+            mock_print.assert_called_once()
+            self.assertEqual(result, [])
+
+    def test_invalid_prompt_type(self):
+        """Test when prompt is not a string"""
+        invalid_content = {
+            "request_form": {
+                "fields": {
+                    "requester_country": {
+                        "prompt_to_select": ["Not a string"],
+                        "countries": ["United Kingdom", "United States", "Canada"]
+                    }
+                }
+            }
+        }
+        with patch('builtins.print') as mock_print:
+            result = prepare_country_options(invalid_content)
+            mock_print.assert_called_once()
+            self.assertEqual(result, [])
+
+    def test_invalid_countries_type(self):
+        """Test when countries is not a list"""
+        invalid_content = {
+            "request_form": {
+                "fields": {
+                    "requester_country": {
+                        "prompt_to_select": "Please select a country",
+                        "countries": "Not a list"
+                    }
+                }
+            }
+        }
+        with patch('builtins.print') as mock_print:
+            result = prepare_country_options(invalid_content)
+            mock_print.assert_called_once()
+            self.assertEqual(result, [])
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Pull Request Overview

This PR introduces two new helper functions to simplify content access in forms. The changes reduce repetitive nested dictionary access by providing cleaner abstractions for retrieving field content and preparing country options.

- Adds `get_field_content` helper function to simplify accessing content from the object based on a YAML structure
- Adds `prepare_country_options` helper function prepares country dropdown choices from content coming from YAML
- Refactors the form class to use these helpers instead of direct dictionary access