### PR TITLE
FOI-15: Prevent direct access to mid-journey pages

### DIFF
--- a/.github/actions/python-tests/action.yml
+++ b/.github/actions/python-tests/action.yml
@@ -6,15 +6,12 @@ runs:
     - uses: actions/setup-python@v5
       with:
         python-version: 3.13
-    - uses: snok/install-poetry@v1
-      with:
-        version: 2.1.2
-        virtualenvs-create: true
-        virtualenvs-in-project: true
-        virtualenvs-path: .venv
-    - name: Install Poetry dependencies
-      run: poetry install --no-interaction --no-root --with dev
+    - name: Start Docker containers
+      run: docker compose up --detach --wait --wait-timeout 300 || docker compose logs app
       shell: bash
-    - name: Run Python tests
-      run: poetry run python -m pytest
+    - name: Install dev dependencies
+      run: docker compose exec app poetry install --no-interaction --no-root --with dev
+      shell: bash
+    - name: Run tests in the app Docker container
+      run: docker compose exec app poetry run python -m pytest
       shell: bash

--- a/.github/actions/python-tests/action.yml
+++ b/.github/actions/python-tests/action.yml
@@ -9,9 +9,6 @@ runs:
     - name: Start Docker containers
       run: docker compose up --detach --wait --wait-timeout 300 || docker compose logs app
       shell: bash
-    - name: Install dev dependencies
-      run: docker compose exec app poetry install --no-interaction --no-root --with dev
-      shell: bash
     - name: Run tests in the app Docker container
-      run: docker compose exec app poetry run python -m pytest
+      run: docker compose exec dev poetry run python -m pytest
       shell: bash

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -7,11 +7,14 @@ from app.lib.template_filters import slugify
 from flask import Flask
 from jinja2 import ChoiceLoader, PackageLoader
 from tna_frontend_jinja.wtforms.helpers import WTFormsHelpers
+from app.lib.requires_session_key import requires_session_key
 
 
 def create_app(config_class):
     app = Flask(__name__, static_url_path="/request-a-service-record/static")
     app.config.from_object(config_class)
+
+    requires_session_key(app)
 
     gunicorn_error_logger = logging.getLogger("gunicorn.error")
     app.logger.handlers.extend(gunicorn_error_logger.handlers)

--- a/app/lib/requires_session_key.py
+++ b/app/lib/requires_session_key.py
@@ -1,0 +1,27 @@
+from flask import Flask, session, redirect, url_for, request, Blueprint, current_app
+
+
+def requires_session_key(app_or_blueprint):
+    @app_or_blueprint.before_request
+    def check_session_key():
+
+        required_key = 'entered_through_index_page'
+        exempt_routes = ['main.index', 'static', 'healthcheck.healthcheck']
+        short_session_id = request.cookies.get('session', 'unknown')[0:7]
+
+        # This path must be exempt because we use it to check for 308 redirects with trailing slashes
+        if request.path == '/healthcheck/live':
+            return
+
+        if request.endpoint and any(request.endpoint.startswith(route) for route in exempt_routes):
+            return
+
+        if required_key not in session or not session[required_key]:
+            current_app.logger.warning(
+                f"'{required_key}' not found or set on {short_session_id} session. Redirecting to start page."
+            )
+            return redirect(url_for('main.index'))
+        else:
+            current_app.logger.debug(
+                f"'{required_key}' found on {short_session_id} session. Proceeding to {request.endpoint}"
+            )

--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -8,6 +8,8 @@ from flask import redirect, render_template, session, url_for
 @bp.route("/")
 @cache.cached(key_prefix=cache_key_prefix)
 def index():
+    session["entered_through_index_page"] = True
+
     content = load_content()
     return render_template("main/index.html", content=content)
 

--- a/config.py
+++ b/config.py
@@ -70,6 +70,7 @@ class Develop(Base, Features):
 
 
 class Test(Base, Features):
+    SECRET_KEY = "abc123"
     DEBUG = True
     TESTING = True
     EXPLAIN_TEMPLATE_LOADING = True

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,8 @@ services:
       - ./:/app
 
   dev:
+    environment:
+      - CONFIG=config.Test
     image: ghcr.io/nationalarchives/tna-python-dev:preview
     volumes:
       - ./:/app

--- a/test/main/test_routes.py
+++ b/test/main/test_routes.py
@@ -20,6 +20,15 @@ class MainBlueprintTestCase(unittest.TestCase):
         self.assertEqual(rv.status_code, 308)
         self.assertEqual(rv.location, f"{self.domain}/healthcheck/live/")
 
+    def test_requires_session_key_redirects(self):
+        rv = self.app.get("/request-a-service-record/all-fields-form/")
+        self.assertEqual(rv.status_code, 302)
+        self.assertEqual(rv.location, f"/request-a-service-record/")
+
+    def test_requires_session_key_does_not_redirect(self):
+        rv = self.app.get("/request-a-service-record/")
+        self.assertEqual(rv.status_code, 200)
+
     def test_homepage(self):
         rv = self.app.get("/request-a-service-record/")
         self.assertEqual(rv.status_code, 200)

--- a/test/playwright/prevent-direct-mid-journey-access.spec.ts
+++ b/test/playwright/prevent-direct-mid-journey-access.spec.ts
@@ -1,0 +1,38 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("accessing mid-journey pages requirements", () => {
+  const INDEX_URL = "/request-a-service-record/";
+  const PROTECTED_URL = "/request-a-service-record/all-fields-form/";
+
+  test.beforeEach(async ({ page }) => {
+    await page.context().clearCookies();
+  });
+
+  test("redirects to index when accessing protected route without session key", async ({
+    page,
+  }) => {
+    const response = await page.goto(PROTECTED_URL);
+
+    // Check that we were redirected to the index page
+    expect(page.url()).toContain(INDEX_URL);
+    expect(response.status()).toBe(200);
+  });
+
+  test("allows access to exempt routes without session key", async ({
+    page,
+  }) => {
+    const response = await page.goto(INDEX_URL);
+
+    expect(page.url()).toContain(INDEX_URL);
+    expect(response.status()).toBe(200);
+  });
+
+  test("healthcheck endpoint is accessible without session key", async ({
+    page,
+  }) => {
+    const response = await page.goto("/healthcheck/live/");
+
+    expect(response.status()).toBe(200);
+    expect(await response.text()).toContain("ok");
+  });
+});


### PR DESCRIPTION
## Description of changes

Prevents access to mid-journey pages without a key that is set on the session when visiting the `main.index` route.

1. `routes.py` is updated to set `entered_through_index_page` on the session
2. `requires_session_key.py` adds a function to the `before_request` in Flask which checks for the key on all but `exempt_routes` and a specific path we're using to check for `308` redirects
3. `__init__.py` is updated to call `requires_session_key(app)`

In addition to the functionality, I've introduced tests in:

1. `test_routes.py` is updated to introduce two tests for `requires_session_key`
2. `prevent-direct-mid-journey-access.spec.ts` is introduced to add Playwright tests for the route protection mechanism.