### PR TITLE
FOI-15: Prevent direct access to mid-journey pages

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -2,6 +2,7 @@ import logging
 
 from app.lib.cache import cache
 from app.lib.context_processor import cookie_preference, now_iso_8601
+from app.lib.requires_session_key import requires_session_key
 from app.lib.talisman import talisman
 from app.lib.template_filters import slugify
 from flask import Flask
@@ -12,6 +13,8 @@ from tna_frontend_jinja.wtforms.helpers import WTFormsHelpers
 def create_app(config_class):
     app = Flask(__name__, static_url_path="/request-a-service-record/static")
     app.config.from_object(config_class)
+
+    requires_session_key(app)
 
     gunicorn_error_logger = logging.getLogger("gunicorn.error")
     app.logger.handlers.extend(gunicorn_error_logger.handlers)

--- a/app/lib/requires_session_key.py
+++ b/app/lib/requires_session_key.py
@@ -1,0 +1,29 @@
+from flask import current_app, redirect, request, session, url_for
+
+
+def requires_session_key(app_or_blueprint):
+    @app_or_blueprint.before_request
+    def check_session_key():
+
+        required_key = "entered_through_index_page"
+        exempt_routes = ["main.index", "static", "healthcheck.healthcheck"]
+        short_session_id = request.cookies.get("session", "unknown")[0:7]
+
+        # This path must be exempt because we use it to check for 308 redirects with trailing slashes
+        if request.path == "/healthcheck/live":
+            return
+
+        if request.endpoint and any(
+            request.endpoint.startswith(route) for route in exempt_routes
+        ):
+            return
+
+        if required_key not in session or not session[required_key]:
+            current_app.logger.warning(
+                f"'{required_key}' not found or set on {short_session_id} session. Redirecting to start page."
+            )
+            return redirect(url_for("main.index"))
+        else:
+            current_app.logger.debug(
+                f"'{required_key}' found on {short_session_id} session. Proceeding to {request.endpoint}"
+            )

--- a/test/main/test_routes.py
+++ b/test/main/test_routes.py
@@ -18,6 +18,15 @@ class MainBlueprintTestCase(unittest.TestCase):
         self.assertEqual(rv.status_code, 308)
         self.assertEqual(rv.location, f"{self.domain}/healthcheck/live/")
 
+    def test_requires_session_key_redirects(self):
+        rv = self.app.get("/request-a-service-record/all-fields-form/")
+        self.assertEqual(rv.status_code, 302)
+        self.assertEqual(rv.location, "/request-a-service-record/")
+
+    def test_requires_session_key_does_not_redirect(self):
+        rv = self.app.get("/request-a-service-record/")
+        self.assertEqual(rv.status_code, 200)
+
     def test_homepage(self):
         rv = self.app.get("/request-a-service-record/")
         self.assertEqual(rv.status_code, 200)

--- a/test/playwright/prevent-direct-mid-journey-access.spec.ts
+++ b/test/playwright/prevent-direct-mid-journey-access.spec.ts
@@ -1,0 +1,38 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("accessing mid-journey pages requirements", () => {
+  const INDEX_URL = "/request-a-service-record/";
+  const PROTECTED_URL = "/request-a-service-record/all-fields-form/";
+
+  test.beforeEach(async ({ page }) => {
+    await page.context().clearCookies();
+  });
+
+  test("redirects to index when accessing protected route without session key", async ({
+    page,
+  }) => {
+    const response = await page.goto(PROTECTED_URL);
+
+    // Check that we were redirected to the index page
+    expect(page.url()).toContain(INDEX_URL);
+    expect(response.status()).toBe(200);
+  });
+
+  test("allows access to exempt routes without session key", async ({
+    page,
+  }) => {
+    const response = await page.goto(INDEX_URL);
+
+    expect(page.url()).toContain(INDEX_URL);
+    expect(response.status()).toBe(200);
+  });
+
+  test("healthcheck endpoint is accessible without session key", async ({
+    page,
+  }) => {
+    const response = await page.goto("/healthcheck/live/");
+
+    expect(response.status()).toBe(200);
+    expect(await response.text()).toContain("ok");
+  });
+});


### PR DESCRIPTION
### Background to this approach

This simply ensures all users begin their journey at the service entry point. From that point it relies on the application routing.

It might be that a future approach enforces a specific path through the user journey, but my sense is that could get very difficult to reason about very quickly. One thing I'm considering here is how easy it will be for future developers (including myself) to understand what's going on.

### A note on "state machines"

I'd initially be considering a some way of potentially using a state machine approach because I've seen this used elsewhere[^1] but I'm currently unconvinced partly because these can get huge and partly because I'm feeling like the application is always stateless at the point a HTTP request is received. I'll keep thinking about this though.

### What this commit does

Adds session key protection to prevent access to mid-journey pages without a key which is on the session when visiting the main.index route.

1. routes.py is updated to set entered_through_index_page on the session
2. requires_session_key.py adds a function to the before_request in Flask which checks for the key on all but exempt_routes and a specific path we're using to check for 308 redirects
3. __init__.py is updated to call requires_session_key(app)

### In addition to the functionality

1. test_routes.py is updated to introduce two tests for requires_session_key
2. prevent-direct-mid-journey-access.spec.ts is introduced to add Playwright tests for the route protection mechanism.

[^1]: https://github.com/govuk-one-login/authentication-frontend/blob/main/src/components/common/state-machine/state-machine.ts