### PR TITLE
Remove redundant condition from requires_session_key

### DIFF
--- a/app/lib/requires_session_key.py
+++ b/app/lib/requires_session_key.py
@@ -9,10 +9,6 @@ def requires_session_key(app_or_blueprint):
         exempt_routes = ["main.index", "static", "healthcheck.healthcheck"]
         short_session_id = request.cookies.get("session", "unknown")[0:7]
 
-        # This path must be exempt because we use it to check for 308 redirects with trailing slashes
-        if request.path == "/healthcheck/live":
-            return
-
         if request.endpoint and any(
             request.endpoint.startswith(route) for route in exempt_routes
         ):


### PR DESCRIPTION
While thinking about possible ways to use before_request I spotted a redundant check for the healthcheck route in requires_session_key (the route is already included in `exempt_routes` so we don't need to check for it again).