### PR TITLE
Add python tests for the state machine

### DIFF
--- a/app/constants.py
+++ b/app/constants.py
@@ -1,5 +1,9 @@
 from enum import Enum
 
+class MultiPageFormRoutes(Enum):
+    IS_SERVICE_PERSON_ALIVE = "main.is_service_person_alive"
+    MUST_SUBMIT_SUBJECT_ACCESS_REQUEST = "main.must_submit_subject_access_request"
+    SERVICE_BRANCH_FORM = "main.service_branch_form"
 
 class ServiceBranches(Enum):
     BRITISH_ARMY = "British Army"

--- a/app/lib/state_machine/state_machine.py
+++ b/app/lib/state_machine/state_machine.py
@@ -1,5 +1,5 @@
 from statemachine import StateMachine, State
-
+from app.constants import MultiPageFormRoutes
 
 class RoutingStateMachine(StateMachine):
     """
@@ -44,13 +44,13 @@ class RoutingStateMachine(StateMachine):
     )
 
     def entering_service_person_alive_form(self, event, state):
-        self.route_for_current_state = "main.is_service_person_alive"
+        self.route_for_current_state = MultiPageFormRoutes.IS_SERVICE_PERSON_ALIVE.value
 
     def entering_subject_access_request_statement(self, event, state):
-        self.route_for_current_state = "main.must_submit_subject_access_request"
+        self.route_for_current_state = MultiPageFormRoutes.MUST_SUBMIT_SUBJECT_ACCESS_REQUEST.value
 
     def entering_service_branch_form(self, event, state):
-        self.route_for_current_state = "main.service_branch_form"
+        self.route_for_current_state = MultiPageFormRoutes.SERVICE_BRANCH_FORM.value
 
     def on_enter_state(self, event, state):
         """This method is called when entering any state."""

--- a/test/main/test_state_machine.py
+++ b/test/main/test_state_machine.py
@@ -1,0 +1,37 @@
+import pytest
+from types import SimpleNamespace
+from app.constants import MultiPageFormRoutes
+from app.lib.state_machine.state_machine import RoutingStateMachine
+
+
+def test_initial_state_has_no_route():
+    sm = RoutingStateMachine()
+    assert sm.current_state.id == "initial"
+    assert sm.route_for_current_state is None
+
+
+def test_continue_to_service_person_alive_form_sets_route():
+    sm = RoutingStateMachine()
+    sm.continue_to_service_person_alive_form()
+    assert sm.current_state.id == "service_person_alive_form"
+    assert sm.route_for_current_state == MultiPageFormRoutes.IS_SERVICE_PERSON_ALIVE.value
+
+
+@pytest.mark.parametrize(
+    "answer,expected_state,expected_route",
+    [
+        ("yes", "subject_access_request_statement", MultiPageFormRoutes.MUST_SUBMIT_SUBJECT_ACCESS_REQUEST.value),
+        ("no", "service_branch_form", MultiPageFormRoutes.SERVICE_BRANCH_FORM.value),
+    ],
+)
+def test_continue_from_service_person_alive_form_routes_by_condition(answer, expected_state, expected_route):
+    sm = RoutingStateMachine()
+    sm.continue_from_service_person_alive_form(form=make_form(answer))
+    assert sm.current_state.id == expected_state
+    assert sm.route_for_current_state == expected_route
+
+
+def make_form(answer: str):
+    return SimpleNamespace(
+        is_service_person_alive=SimpleNamespace(data=answer)
+    )


### PR DESCRIPTION
While there are already Playwright tests and the state machine provides several correctness guarantees[^1], these additional tests will confirm that the correct states and routes are returned following a given transition

[^1]: https://python-statemachine.readthedocs.io/en/latest/readme.html - See "Correctness guarantees" on this page