### PR TITLE
Update "Is service person alive" to include "I don't know"

### DIFF
--- a/app/constants.py
+++ b/app/constants.py
@@ -4,6 +4,7 @@ class MultiPageFormRoutes(Enum):
     IS_SERVICE_PERSON_ALIVE = "main.is_service_person_alive"
     MUST_SUBMIT_SUBJECT_ACCESS_REQUEST = "main.must_submit_subject_access_request"
     SERVICE_BRANCH_FORM = "main.service_branch_form"
+    ONLY_LIVING_SUBJECTS_CAN_REQUEST_THEIR_RECORD = "main.only_living_subjects_can_request_their_record"
 
 class ServiceBranches(Enum):
     BRITISH_ARMY = "British Army"

--- a/app/content/content.yaml
+++ b/app/content/content.yaml
@@ -5,6 +5,10 @@ pages:
     heading: Request a military service record
   must_submit_subject_access_request:
     heading: Submit a data request for a living subject
+  only_living_subjects_can_request_their_record:
+    heading: Service records of living persons can only be released to themselves
+    paragraphs:
+      - Unfortunately we won't be able to release the record to you.
   all_fields_in_one_form:
     service_person_details:
       legend: Service person detail

--- a/app/main/forms/is_service_person_alive.py
+++ b/app/main/forms/is_service_person_alive.py
@@ -18,7 +18,7 @@ class IsServicePersonAlive(FlaskForm):
 
     is_service_person_alive = RadioField(
         get_field_content(content, "is_service_person_alive", "label"),
-        choices=[("yes", "Yes"), ("no", "No")],
+        choices=[("yes", "Yes"), ("no", "No"), ("unsure", "I don't know")],
         validators=[
             InputRequired(
                 message=get_field_content(content, "is_service_person_alive", "messages")[

--- a/app/main/routes/routes_multiple_forms_journey.py
+++ b/app/main/routes/routes_multiple_forms_journey.py
@@ -40,6 +40,12 @@ def must_submit_subject_access_request():
         "main/multi-page-journey/must-submit-subject-access-request.html", content=load_content()
     )
 
+@bp.route("/only-living-subjects-can-request-their-record/", methods=["GET"])
+def only_living_subjects_can_request_their_record():
+    return render_template(
+        "main/multi-page-journey/only-living-subjects-can-request-their-record.html",
+        content=load_content(),
+    )
 
 @bp.route("/service-branch/", methods=["GET"])
 def service_branch_form():

--- a/app/templates/main/multi-page-journey/only-living-subjects-can-request-their-record.html
+++ b/app/templates/main/multi-page-journey/only-living-subjects-can-request-their-record.html
@@ -1,0 +1,17 @@
+{% extends 'base.html' %}
+
+{%- set pageTitle = content.app.title -%}
+
+{% block content %}
+  <div class="tna-section">
+    <div class="tna-container">
+      <div
+        class="tna-column tna-column--width-2-3 tna-column--width-5-6-medium tna-column--full-small tna-column--full-tiny">
+        <h1 class="tna-heading-xl">{{ content.pages.only_living_subjects_can_request_their_record.heading }}</h1>
+        {% for paragraph in content.pages.only_living_subjects_can_request_their_record.paragraphs %}
+          <p>{{ paragraph }}</p>
+        {% endfor %}
+      </div>
+    </div>
+  </div>
+{% endblock %}

--- a/test/main/test_state_machine.py
+++ b/test/main/test_state_machine.py
@@ -22,6 +22,7 @@ def test_continue_to_service_person_alive_form_sets_route():
     [
         ("yes", "subject_access_request_statement", MultiPageFormRoutes.MUST_SUBMIT_SUBJECT_ACCESS_REQUEST.value),
         ("no", "service_branch_form", MultiPageFormRoutes.SERVICE_BRANCH_FORM.value),
+        ("unsure", "only_living_subjects_can_request_their_record_statement", MultiPageFormRoutes.ONLY_LIVING_SUBJECTS_CAN_REQUEST_THEIR_RECORD.value),
     ],
 )
 def test_continue_from_service_person_alive_form_routes_by_condition(answer, expected_state, expected_route):

--- a/test/playwright/multi-page-journey/is-service-person-alive.spec.ts
+++ b/test/playwright/multi-page-journey/is-service-person-alive.spec.ts
@@ -7,6 +7,8 @@ test.describe("is this person still alive", () => {
   const MUST_SUBMIT_SUBJECT_ACCESS_URL =
     "/request-a-service-record/must-submit-subject-access/";
   const SELECT_SERVICE_BRANCH_URL = "/request-a-service-record/service-branch/";
+  const ONLY_LIVING_SUBJECTS_CAN_REQUEST_THEIR_OWN_RECORD =
+    "/request-a-service-record/only-living-subjects-can-request-their-record/";
 
   test.beforeEach(async ({ page }) => {
     await page.goto(JOURNEY_START_PAGE_URL); // We need to go here first because we prevent direct access to mid-journey pages
@@ -40,11 +42,24 @@ test.describe("is this person still alive", () => {
   test("Presents the 'Service branch' form when 'No' is selected", async ({
     page,
   }) => {
-    await page.getByLabel("No").check();
+    await page.getByLabel("No", { exact: true }).check();
     await page.getByRole("button", { name: /Continue/i }).click();
     await expect(page).toHaveURL(SELECT_SERVICE_BRANCH_URL);
     await expect(page.locator("h1")).toHaveText(
       /What was the person's service branch\?/,
+    );
+  });
+
+  test("Presents the page explaining records for living persons can only be released to themselves when 'I don't know' is selected", async ({
+    page,
+  }) => {
+    await page.getByLabel("I don't know", { exact: true }).check();
+    await page.getByRole("button", { name: /Continue/i }).click();
+    await expect(page).toHaveURL(
+      ONLY_LIVING_SUBJECTS_CAN_REQUEST_THEIR_OWN_RECORD,
+    );
+    await expect(page.locator("h1")).toHaveText(
+      /Service records of living persons can only be released to themselves/,
     );
   });
 });


### PR DESCRIPTION
Discussion with the PM this afternoon revealed the need to include an "I don't know" option when users are asked if the service person is alive and a new page explaining that it's only living persons who can request their service record.

This commit:

1. Updates `state_machine.py` to introduce the new state (sadly, this required another two functions because it's no longer a boolean - I'd liked the simplicity of a single function)
2. Adds the new template and a new section for the page in `content.yaml`
3. Updates the field to introduce the new option
4. Updates the state machine tests and Playwright tests to cover all the scenarios
5. Adds a new route function