### PR TITLE
Handle return from GOV.UK Pay 

### DIFF
--- a/app/lib/db_handler.py
+++ b/app/lib/db_handler.py
@@ -2,17 +2,28 @@ from app.lib.models import ServiceRecordRequest, db
 from flask import current_app
 
 
-def get_service_record_request(payment_id: str) -> ServiceRecordRequest | None:
-    record = None
+def get_service_record_request(*, payment_id: str | None = None, record_id: str | None = None) -> ServiceRecordRequest | None:
+    """
+    Get a ServiceRecordRequest item by payment_id or record_id.
+    Must provide either a payment_id OR a record_id.
+    """
+    if (payment_id is None and record_id is None) or (payment_id is not None and record_id is not None):
+        raise ValueError("Invalid parameters: provide either payment_id or record_id.")
 
     try:
-        record = (
-            db.session.query(ServiceRecordRequest)
-            .filter_by(payment_id=payment_id)
-            .first()
-        )
+        if record_id is not None:
+            record = (
+                db.session.get(ServiceRecordRequest, record_id)
+            )
+        else:
+            record = (
+                db.session.query(ServiceRecordRequest)
+                .filter_by(payment_id=payment_id)
+                .first()
+            )
     except Exception as e:
         current_app.logger.error(f"Error fetching service record request: {e}")
+        return None
 
     if not record:
         current_app.logger.error(

--- a/app/lib/db_handler.py
+++ b/app/lib/db_handler.py
@@ -32,6 +32,9 @@ def get_service_record_request(*, payment_id: str | None = None, record_id: str 
 
     return record
 
+def get_payment_id_from_record_id(record_id: str) -> str | None:
+    record = get_service_record_request(record_id=record_id)
+    return record.payment_id if record else None
 
 def add_service_record_request(data: dict) -> None:
     try:

--- a/app/lib/gov_uk_pay.py
+++ b/app/lib/gov_uk_pay.py
@@ -10,7 +10,7 @@ from flask import current_app
 
 class GOV_UK_PAY_EVENT_TYPES(Enum):
     EXPIRED = "card_payment_expired"
-    CANCELLED = "card_payment_cancelled"
+    FAILED = "card_payment_failed"
     SUCCEEDED = "card_payment_succeeded"
 
 SUCCESS_PAYMENT_STATUSES: set[str] = {

--- a/app/lib/gov_uk_pay.py
+++ b/app/lib/gov_uk_pay.py
@@ -13,7 +13,22 @@ class GOV_UK_PAY_EVENT_TYPES(Enum):
     CANCELLED = "card_payment_cancelled"
     SUCCEEDED = "card_payment_succeeded"
 
+SUCCESS_PAYMENT_STATUSES: set[str] = {
+    "success"
+}
 
+IN_PROGRESS_PAYMENT_STATUSES: set[str] = {
+    "created",
+    "submitted",
+    "started",
+    "capturable"
+}
+
+FAILED_PAYMENT_STATUSES: set[str] = {
+    "failed",
+    "cancelled",
+    "error"
+}
 
 def get_payment_status(payment_id: str) -> dict | None:
     headers = {
@@ -39,7 +54,7 @@ def validate_payment(payment_id: str) -> bool:
     payment_status = get_payment_status(payment_id)
     if payment_status is None:
         return False
-    return payment_status.get("state").get("status") == "success"
+    return payment_status.get("state").get("status") in SUCCESS_PAYMENT_STATUSES
 
 
 def create_payment(

--- a/app/lib/gov_uk_pay.py
+++ b/app/lib/gov_uk_pay.py
@@ -92,7 +92,7 @@ def create_payment(
     return response.json()
 
 
-def is_webhook_signature_valid(request: requests.Request) -> bool:
+def validate_webhook_signature(request: requests.Request) -> bool:
     signing_secret = current_app.config["GOV_UK_PAY_SIGNING_SECRET"]
     pay_signature = request.headers.get("Pay-Signature", "")
     body = request.get_data()

--- a/app/lib/gov_uk_pay.py
+++ b/app/lib/gov_uk_pay.py
@@ -30,7 +30,7 @@ FAILED_PAYMENT_STATUSES: set[str] = {
     "error"
 }
 
-def get_payment_status(payment_id: str) -> dict | None:
+def get_payment_data(payment_id: str) -> dict | None:
     headers = {
         "Authorization": f"Bearer {current_app.config["GOV_UK_PAY_API_KEY"]}",
         "Content-Type": "application/json",
@@ -44,17 +44,21 @@ def get_payment_status(payment_id: str) -> dict | None:
     try:
         response.raise_for_status()
     except Exception as e:
-        current_app.logger.error(f"Error fetching payment status: {e}")
+        current_app.logger.error(f"Error fetching payment data: {e}")
         return None
 
     return response.json()
 
 
+def get_payment_status(payment_id: str) -> dict | None:
+    data = get_payment_data(payment_id)
+    if data is None:
+        return None
+    return data.get("state").get("status")
+
+
 def validate_payment(payment_id: str) -> bool:
-    payment_status = get_payment_status(payment_id)
-    if payment_status is None:
-        return False
-    return payment_status.get("state").get("status") in SUCCESS_PAYMENT_STATUSES
+    return get_payment_status(payment_id) in SUCCESS_PAYMENT_STATUSES
 
 
 def create_payment(

--- a/app/lib/gov_uk_pay.py
+++ b/app/lib/gov_uk_pay.py
@@ -35,6 +35,13 @@ def get_payment_status(payment_id: str) -> dict | None:
     return response.json()
 
 
+def validate_payment(payment_id: str) -> bool:
+    payment_status = get_payment_status(payment_id)
+    if payment_status is None:
+        return False
+    return payment_status.get("state").get("status") == "success"
+
+
 def create_payment(
     amount: int, description: str, reference: str, email: str | None, return_url: str
 ) -> dict | None:

--- a/app/lib/models.py
+++ b/app/lib/models.py
@@ -6,7 +6,7 @@ db = SQLAlchemy()
 class ServiceRecordRequest(db.Model):
     __tablename__ = "service_record_requests"
 
-    id = db.Column(db.Integer, primary_key=True)
+    id = db.Column(db.String(64), primary_key=True)
     additional_information = db.Column(db.Text, nullable=True)
     case_reference_number = db.Column(db.String(64), nullable=True)
     date_of_birth = db.Column(db.DateTime)
@@ -33,6 +33,6 @@ class ServiceRecordRequest(db.Model):
     service_number = db.Column(db.String(64), nullable=True)
     evidence_of_death = db.Column(
         db.String(64), nullable=True
-    )  # TODO: Needs to store UUID generated when saving file to S3
+    )
     payment_id = db.Column(db.String(64), nullable=True, unique=True)
     created_at = db.Column(db.DateTime, default=db.func.current_timestamp())

--- a/app/main/routes/routes_single_form_journey.py
+++ b/app/main/routes/routes_single_form_journey.py
@@ -116,6 +116,7 @@ def handle_gov_uk_pay_response():
     if validate_payment(payment_id):
         return redirect(url_for("main.confirm_payment_received"))
 
+    # Let the user know it failed, ask if they want to retry
     return redirect(url_for("main.payment_incomplete"))
 
 

--- a/app/main/routes/routes_single_form_journey.py
+++ b/app/main/routes/routes_single_form_journey.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 
+import uuid
 from app.lib.aws import upload_proof_of_death
 from app.lib.cache import cache, cache_key_prefix
 from app.lib.content import load_content
@@ -62,12 +63,14 @@ def send_to_gov_pay():
     form_data = session.get("form_data", {})
     requester_email = form_data.get("requester_email", None)
 
+    id = str(uuid.uuid4())
+
     response = create_payment(
         amount=1000,
         description=content["app"]["title"],
         reference="ServiceRecordRequest",
         email=requester_email,
-        return_url=url_for("main.handle_gov_uk_pay_response", _external=True),
+        return_url=f"{url_for("main.handle_gov_uk_pay_response", _external=True)}?id={id}",
     )
 
     if not response:
@@ -87,7 +90,7 @@ def send_to_gov_pay():
             else None
         )
 
-        data = {**form_data, "payment_id": payment_id, "created_at": datetime.now()}
+        data = {**form_data, "id": id, "payment_id": payment_id, "created_at": datetime.now()}
 
         data["date_of_birth"] = (
             date_of_birth  # TODO: Temporary until full implementation, date_of_birth/death will be a string

--- a/app/main/routes/routes_single_form_journey.py
+++ b/app/main/routes/routes_single_form_journey.py
@@ -113,6 +113,10 @@ def handle_gov_uk_pay_response():
     
     payment_id = get_payment_id_from_record_id(id)
 
+    if payment_id is None:
+        # User got here with an ID that doesn't exist in the DB - could be our fault, or could be malicious, do something
+        return "Shouldn't be here"
+
     if validate_payment(payment_id):
         return redirect(url_for("main.confirm_payment_received"))
 

--- a/app/main/routes/routes_single_form_journey.py
+++ b/app/main/routes/routes_single_form_journey.py
@@ -7,9 +7,9 @@ from app.lib.content import load_content
 from app.lib.db_handler import add_service_record_request, get_payment_id_from_record_id
 from app.lib.gov_uk_pay import (
     create_payment,
-    is_webhook_signature_valid,
+    validate_webhook_signature,
     process_webhook_data,
-    validate_payment
+    validate_payment,
 )
 from app.main import bp
 from app.main.forms.proceed_to_pay import ProceedToPay
@@ -141,7 +141,7 @@ def confirm_payment_received():
 @bp.route("/gov-uk-pay-webhook/", methods=["POST"])
 def gov_uk_pay_webhook():
 
-    if not is_webhook_signature_valid(request):
+    if not validate_webhook_signature(request):
         return "FAILED", 403
 
     try:

--- a/test/main/test_database.py
+++ b/test/main/test_database.py
@@ -37,6 +37,7 @@ def test_add_service_record_request(session):
 
     add_service_record_request(
         {
+            "id": "testrecordid123",
             "forenames": "John",
             "lastname": "Doe",
             "requester_email": "john.doe@email.com",
@@ -48,16 +49,25 @@ def test_add_service_record_request(session):
             "payment_id": payment_id,
         }
     )
-    result = get_service_record_request(payment_id)
+    result = get_service_record_request(payment_id=payment_id)
     assert result is not None
     assert result.forenames == "John"
     assert result.requester_email == "john.doe@email.com"
 
 
-def test_get_service_record_request(session):
+def test_get_service_record_request_by_payment_id(session):
     payment_id = "testpaymentid123"
 
-    result = get_service_record_request(payment_id)
+    result = get_service_record_request(payment_id=payment_id)
+    assert result is not None
+    assert result.forenames == "John"
+    assert result.requester_email == "john.doe@email.com"
+
+
+def test_get_service_record_request_by_record_id(session):
+    record_id = "testrecordid123"
+
+    result = get_service_record_request(record_id=record_id)
     assert result is not None
     assert result.forenames == "John"
     assert result.requester_email == "john.doe@email.com"
@@ -79,9 +89,9 @@ def test_delete_service_record_request(session):
             "payment_id": payment_id,
         }
     )
-    record = get_service_record_request(payment_id)
+    record = get_service_record_request(payment_id=payment_id)
     assert record is not None
 
     delete_service_record_request(record)
-    deleted = get_service_record_request(payment_id)
+    deleted = get_service_record_request(payment_id=payment_id)
     assert deleted is None

--- a/test/main/test_gov_uk.py
+++ b/test/main/test_gov_uk.py
@@ -6,7 +6,7 @@ import pytest
 from app.lib.gov_uk_pay import (
     GOV_UK_PAY_EVENT_TYPES,
     create_payment,
-    is_webhook_signature_valid,
+    validate_webhook_signature,
     process_webhook_data,
 )
 
@@ -47,7 +47,7 @@ def test_create_payment_failure(mock_post, test_app):
         assert result is None
 
 
-def test_is_webhook_signature_valid(test_app):
+def test_validate_webhook_signature(test_app):
     class DummyRequest:
         def __init__(self, data, signature):
             self._data = data
@@ -61,9 +61,9 @@ def test_is_webhook_signature_valid(test_app):
         payload = b"test"
         signature = hmac.new(b"secret", payload, hashlib.sha256).hexdigest()
         req = DummyRequest(payload, signature)
-        assert is_webhook_signature_valid(req) is True
+        assert validate_webhook_signature(req) is True
         req = DummyRequest(payload, "wrong")
-        assert is_webhook_signature_valid(req) is False
+        assert validate_webhook_signature(req) is False
 
 
 def test_process_webhook_events(test_app):


### PR DESCRIPTION
This PR allows us to:
1. Create a UUID when the user goes to GOV.UK Pay
2. Save user's form data with UUID as the DB row's ID
3. We provide this UUID as a URL param on the `return_url` we provide to GOV.UK Pay (where the user gets redirected)
4. User gets redirected back to us (we have no knowledge of if a payment has failed or not)
5. Get the UUID from the URL param
6. If there is no UUID in the URL param - they're likely here manually (provide a message, TBC)
7. Check the DB for row of UUID
8. If DB row exists, then get the `payment_id` (if not, do something, could be an error or malicious attempts)
9. Query GOV.UK Pay API with `payment_id`
10. Check `state.status` to see what the outcome of the payment was
11. Redirect user based on status (mostly TBC, if it's anything other than "success", we'll likely want to send the user to a "retry" page)