### PR TITLE
FOI-47: Add service branch routing

### DIFF
--- a/app/constants.py
+++ b/app/constants.py
@@ -1,16 +1,23 @@
 from enum import Enum
 
+
 class MultiPageFormRoutes(Enum):
     IS_SERVICE_PERSON_ALIVE = "main.is_service_person_alive"
     MUST_SUBMIT_SUBJECT_ACCESS_REQUEST = "main.must_submit_subject_access_request"
     SERVICE_BRANCH_FORM = "main.service_branch_form"
     ONLY_LIVING_SUBJECTS_CAN_REQUEST_THEIR_RECORD = "main.only_living_subjects_can_request_their_record"
+    WAS_SERVICE_PERSON_OFFICER_FORM = "main.was_service_person_officer_form"
+    MOD_HAVE_THIS_RECORD = "main.mod_have_this_record"
+    CHECK_ANCESTRY = "main.check_ancestry"
+
 
 class ServiceBranches(Enum):
     BRITISH_ARMY = "British Army"
     ROYAL_AIR_FORCE = "Royal Air Force"
     ROYAL_NAVY = "Royal Navy"
     HOME_GUARD = "Home Guard"
+    BRITISH_ARMY_OTHER = "British Army: Other (e.g. Kenya Regiment, Hong Kong Regiment)"
+    UNKNOWN = "I don't know"
 
 
 class Ranks(Enum):

--- a/app/content/content.yaml
+++ b/app/content/content.yaml
@@ -9,6 +9,14 @@ pages:
     heading: Service records of living persons can only be released to themselves
     paragraphs:
       - Unfortunately we won't be able to release the record to you.
+  mod_have_this_record:
+    heading: The Ministry of Defence has this record
+  was_service_person_an_officer:
+    heading: Was the service person an officer?
+  check_ancestry:
+    heading: Check Ancestry
+    paragraphs:
+      - Home Guard records are in the process of being digitised by Ancestry. Check there first
   all_fields_in_one_form:
     service_person_details:
       legend: Service person detail

--- a/app/lib/state_machine/state_machine.py
+++ b/app/lib/state_machine/state_machine.py
@@ -1,6 +1,7 @@
 from statemachine import StateMachine, State
 from app.constants import MultiPageFormRoutes
 
+
 class RoutingStateMachine(StateMachine):
     """
     _route_for_current_state is updated by entering_* methods to indicate the route to be used for the current state
@@ -30,7 +31,11 @@ class RoutingStateMachine(StateMachine):
     service_person_alive_form = State(enter="entering_service_person_alive_form", final=True)
     subject_access_request_statement = State(enter="entering_subject_access_request_statement", final=True)
     service_branch_form = State(enter="entering_service_branch_form", final=True)
-    only_living_subjects_can_request_their_record_statement = State(enter="entering_only_living_subjects_can_request_their_record_statement", final=True)
+    only_living_subjects_can_request_their_record_statement = State(
+        enter="entering_only_living_subjects_can_request_their_record_statement", final=True)
+    was_service_person_officer_form = State(enter="entering_was_service_person_officer_form", final=True)
+    mod_have_this_record_statement = State(enter="entering_mod_have_this_record", final=True)
+    check_ancestry_statement = State(enter="entering_check_ancestry_statement", final=True)
     """
     These are our Events. We call these in route methods to trigger transitions between States.
 
@@ -40,9 +45,14 @@ class RoutingStateMachine(StateMachine):
     """
     continue_to_service_person_alive_form = initial.to(service_person_alive_form)
     continue_from_service_person_alive_form = (
-        initial.to(subject_access_request_statement, cond="living_subject")
-        | initial.to(service_branch_form, cond="deceased_subject")
-        | initial.to(only_living_subjects_can_request_their_record_statement, cond="potentially_living_subject")
+            initial.to(subject_access_request_statement, cond="living_subject")
+            | initial.to(service_branch_form, cond="deceased_subject")
+            | initial.to(only_living_subjects_can_request_their_record_statement, cond="potentially_living_subject")
+    )
+    continue_from_service_branch_form = (
+            initial.to(was_service_person_officer_form, unless="go_to_mod or check_ancestry")
+            | initial.to(mod_have_this_record_statement, cond="go_to_mod")
+            | initial.to(check_ancestry_statement, cond="check_ancestry")
     )
 
     def entering_service_person_alive_form(self, event, state):
@@ -57,9 +67,19 @@ class RoutingStateMachine(StateMachine):
     def entering_only_living_subjects_can_request_their_record_statement(self, event, state):
         self.route_for_current_state = MultiPageFormRoutes.ONLY_LIVING_SUBJECTS_CAN_REQUEST_THEIR_RECORD.value
 
+    def entering_was_service_person_officer_form(self, form):
+        self.route_for_current_state = MultiPageFormRoutes.WAS_SERVICE_PERSON_OFFICER_FORM.value
+
+    def entering_mod_have_this_record(self, form):
+        self.route_for_current_state = MultiPageFormRoutes.MOD_HAVE_THIS_RECORD.value
+
+    def entering_check_ancestry_statement(self, form):
+        self.route_for_current_state = MultiPageFormRoutes.CHECK_ANCESTRY.value
+
     def on_enter_state(self, event, state):
         """This method is called when entering any state."""
-        print(f"State machine: Entering '{state.id}' state in response to '{event}' event. The next route is set to: '{self.route_for_current_state}'")
+        print(
+            f"State machine: Entering '{state.id}' state in response to '{event}' event. The next route is set to: '{self.route_for_current_state}'")
 
     def on_exit_state(self, event, state):
         """This method is called when exiting any state."""
@@ -69,6 +89,14 @@ class RoutingStateMachine(StateMachine):
     def living_subject(self, form):
         """Condition method to determine if the service person is alive."""
         return form.is_service_person_alive.data == "yes"
+
+    def go_to_mod(self, form):
+        """Condition method to determine if the user should be directed to the MOD."""
+        return form.service_branch.data in ["ROYAL_NAVY"]
+
+    def check_ancestry(self, form):
+        """Condition method to determine if the user should be directed to the check Ancestry."""
+        return form.service_branch.data in ["HOME_GUARD"]
 
     def deceased_subject(self, form):
         """Condition method to determine if the service person is deceased."""

--- a/app/main/routes/routes_multiple_forms_journey.py
+++ b/app/main/routes/routes_multiple_forms_journey.py
@@ -20,6 +20,7 @@ def start(state_machine):
         "main/multi-page-journey/start.html", form=form, content=load_content()
     )
 
+
 @bp.route("/is-service-person-alive/", methods=["GET", "POST"])
 @with_state_machine
 def is_service_person_alive(state_machine):
@@ -40,6 +41,7 @@ def must_submit_subject_access_request():
         "main/multi-page-journey/must-submit-subject-access-request.html", content=load_content()
     )
 
+
 @bp.route("/only-living-subjects-can-request-their-record/", methods=["GET"])
 def only_living_subjects_can_request_their_record():
     return render_template(
@@ -47,9 +49,37 @@ def only_living_subjects_can_request_their_record():
         content=load_content(),
     )
 
-@bp.route("/service-branch/", methods=["GET"])
-def service_branch_form():
+
+@bp.route("/service-branch/", methods=["GET", "POST"])
+@with_state_machine
+def service_branch_form(state_machine):
     form = ServiceBranch()
+
+    if form.validate_on_submit():
+        state_machine.continue_from_service_branch_form(form)
+        return redirect(url_for(state_machine.route_for_current_state))
+
     return render_template(
         "main/multi-page-journey/service-branch.html", form=form, content=load_content()
+    )
+
+
+@bp.route("/mod-have-this-record/", methods=["GET"])
+def mod_have_this_record():
+    return render_template(
+        "main/multi-page-journey/mod-have-this-record.html", content=load_content()
+    )
+
+
+@bp.route("/was-service-person-officer/", methods=["GET"])
+def was_service_person_officer_form():
+    return render_template(
+        "main/multi-page-journey/was-service-person-an-officer.html", content=load_content()
+    )
+
+
+@bp.route("/check-ancestry/", methods=["GET"])
+def check_ancestry():
+    return render_template(
+        "main/multi-page-journey/check-ancestry.html", content=load_content()
     )

--- a/app/templates/main/multi-page-journey/check-ancestry.html
+++ b/app/templates/main/multi-page-journey/check-ancestry.html
@@ -1,0 +1,17 @@
+{% extends 'base.html' %}
+
+{%- set pageTitle = content.app.title -%}
+
+{% block content %}
+  <div class="tna-section">
+    <div class="tna-container">
+      <div
+        class="tna-column tna-column--width-2-3 tna-column--width-5-6-medium tna-column--full-small tna-column--full-tiny">
+        <h1 class="tna-heading-xl">{{ content.pages.check_ancestry.heading }}</h1>
+        {% for paragraph in content.pages.check_ancestry.paragraphs %}
+          <p>{{ paragraph }}</p>
+        {% endfor %}
+      </div>
+    </div>
+  </div>
+{% endblock %}

--- a/app/templates/main/multi-page-journey/mod-have-this-record.html
+++ b/app/templates/main/multi-page-journey/mod-have-this-record.html
@@ -1,0 +1,15 @@
+{% extends 'base.html' %}
+
+{%- set pageTitle = content.app.title -%}
+
+{% block content %}
+  <div class="tna-section">
+    <div class="tna-container">
+      <div
+        class="tna-column tna-column--width-2-3 tna-column--width-5-6-medium tna-column--full-small tna-column--full-tiny">
+        <h1 class="tna-heading-xl">{{ content.pages.mod_have_this_record.heading }}</h1>
+        <p>[Content TBC]</p>
+      </div>
+    </div>
+  </div>
+{% endblock %}

--- a/app/templates/main/multi-page-journey/was-service-person-an-officer.html
+++ b/app/templates/main/multi-page-journey/was-service-person-an-officer.html
@@ -1,0 +1,15 @@
+{% extends 'base.html' %}
+
+{%- set pageTitle = content.app.title -%}
+
+{% block content %}
+  <div class="tna-section">
+    <div class="tna-container">
+      <div
+        class="tna-column tna-column--width-2-3 tna-column--width-5-6-medium tna-column--full-small tna-column--full-tiny">
+        <h1 class="tna-heading-xl">{{ content.pages.was_service_person_an_officer.heading }}</h1>
+        <p>[Content TBC]</p>
+      </div>
+    </div>
+  </div>
+{% endblock %}

--- a/test/main/test_state_machine.py
+++ b/test/main/test_state_machine.py
@@ -22,7 +22,8 @@ def test_continue_to_service_person_alive_form_sets_route():
     [
         ("yes", "subject_access_request_statement", MultiPageFormRoutes.MUST_SUBMIT_SUBJECT_ACCESS_REQUEST.value),
         ("no", "service_branch_form", MultiPageFormRoutes.SERVICE_BRANCH_FORM.value),
-        ("unsure", "only_living_subjects_can_request_their_record_statement", MultiPageFormRoutes.ONLY_LIVING_SUBJECTS_CAN_REQUEST_THEIR_RECORD.value),
+        ("unsure", "only_living_subjects_can_request_their_record_statement",
+         MultiPageFormRoutes.ONLY_LIVING_SUBJECTS_CAN_REQUEST_THEIR_RECORD.value),
     ],
 )
 def test_continue_from_service_person_alive_form_routes_by_condition(answer, expected_state, expected_route):
@@ -32,7 +33,28 @@ def test_continue_from_service_person_alive_form_routes_by_condition(answer, exp
     assert sm.route_for_current_state == expected_route
 
 
+@pytest.mark.parametrize(
+    "answer,expected_state,expected_route",
+    [
+        ("BRITISH_ARMY", "was_service_person_officer_form", MultiPageFormRoutes.WAS_SERVICE_PERSON_OFFICER_FORM.value),
+        ("ROYAL_NAVY", "mod_have_this_record_statement", MultiPageFormRoutes.MOD_HAVE_THIS_RECORD.value),
+        ("HOME_GUARD", "check_ancestry_statement", MultiPageFormRoutes.CHECK_ANCESTRY.value),
+        ("ROYAL_AIR_FORCE", "was_service_person_officer_form",
+         MultiPageFormRoutes.WAS_SERVICE_PERSON_OFFICER_FORM.value),
+        ("BRITISH_ARMY_OTHER", "was_service_person_officer_form",
+         MultiPageFormRoutes.WAS_SERVICE_PERSON_OFFICER_FORM.value),
+        ("UNKNOWN", "was_service_person_officer_form", MultiPageFormRoutes.WAS_SERVICE_PERSON_OFFICER_FORM.value),
+    ],
+)
+def test_continue_from_service_branch_form_routes_by_condition(answer, expected_state, expected_route):
+    sm = RoutingStateMachine()
+    sm.continue_from_service_branch_form(form=make_form(answer))
+    assert sm.current_state.id == expected_state
+    assert sm.route_for_current_state == expected_route
+
+
 def make_form(answer: str):
     return SimpleNamespace(
-        is_service_person_alive=SimpleNamespace(data=answer)
+        is_service_person_alive=SimpleNamespace(data=answer),
+        service_branch=SimpleNamespace(data=answer)
     )

--- a/test/playwright/multi-page-journey/is-service-person-alive.spec.ts
+++ b/test/playwright/multi-page-journey/is-service-person-alive.spec.ts
@@ -1,18 +1,19 @@
 import { test, expect } from "@playwright/test";
 
 test.describe("is this person still alive", () => {
-  const JOURNEY_START_PAGE_URL = "/request-a-service-record/start/";
-  const IS_SERVICE_PERSON_ALIVE_URL =
-    "/request-a-service-record/is-service-person-alive/";
-  const MUST_SUBMIT_SUBJECT_ACCESS_URL =
-    "/request-a-service-record/must-submit-subject-access/";
-  const SELECT_SERVICE_BRANCH_URL = "/request-a-service-record/service-branch/";
-  const ONLY_LIVING_SUBJECTS_CAN_REQUEST_THEIR_OWN_RECORD =
-    "/request-a-service-record/only-living-subjects-can-request-their-record/";
+  const basePath = "/request-a-service-record";
+
+  enum Urls {
+    JOURNEY_START_PAGE = `${basePath}/start/`,
+    IS_SERVICE_PERSON_ALIVE = `${basePath}/is-service-person-alive/`,
+    MUST_SUBMIT_SUBJECT_ACCESS = `${basePath}/must-submit-subject-access/`,
+    SELECT_SERVICE_BRANCH = `${basePath}/service-branch/`,
+    ONLY_LIVING_SUBJECTS_CAN_REQUEST_THEIR_OWN_RECORD = `${basePath}/only-living-subjects-can-request-their-record/`,
+  }
 
   test.beforeEach(async ({ page }) => {
-    await page.goto(JOURNEY_START_PAGE_URL); // We need to go here first because we prevent direct access to mid-journey pages
-    await page.goto(IS_SERVICE_PERSON_ALIVE_URL);
+    await page.goto(Urls.JOURNEY_START_PAGE); // We need to go here first because we prevent direct access to mid-journey pages
+    await page.goto(Urls.IS_SERVICE_PERSON_ALIVE);
   });
 
   test("Shows the correct heading", async ({ page }) => {
@@ -33,7 +34,7 @@ test.describe("is this person still alive", () => {
   }) => {
     await page.getByLabel("Yes").check();
     await page.getByRole("button", { name: /Continue/i }).click();
-    await expect(page).toHaveURL(MUST_SUBMIT_SUBJECT_ACCESS_URL);
+    await expect(page).toHaveURL(Urls.MUST_SUBMIT_SUBJECT_ACCESS);
     await expect(page.locator("h1")).toHaveText(
       /Submit a data request for a living subject/,
     );
@@ -44,7 +45,7 @@ test.describe("is this person still alive", () => {
   }) => {
     await page.getByLabel("No", { exact: true }).check();
     await page.getByRole("button", { name: /Continue/i }).click();
-    await expect(page).toHaveURL(SELECT_SERVICE_BRANCH_URL);
+    await expect(page).toHaveURL(Urls.SELECT_SERVICE_BRANCH);
     await expect(page.locator("h1")).toHaveText(
       /What was the person's service branch\?/,
     );
@@ -56,7 +57,7 @@ test.describe("is this person still alive", () => {
     await page.getByLabel("I don't know", { exact: true }).check();
     await page.getByRole("button", { name: /Continue/i }).click();
     await expect(page).toHaveURL(
-      ONLY_LIVING_SUBJECTS_CAN_REQUEST_THEIR_OWN_RECORD,
+      Urls.ONLY_LIVING_SUBJECTS_CAN_REQUEST_THEIR_OWN_RECORD,
     );
     await expect(page.locator("h1")).toHaveText(
       /Service records of living persons can only be released to themselves/,

--- a/test/playwright/multi-page-journey/service-branch.spec.ts
+++ b/test/playwright/multi-page-journey/service-branch.spec.ts
@@ -1,16 +1,19 @@
 import { test, expect } from "@playwright/test";
 
 test.describe("What was the person's service branch?", () => {
-  const JOURNEY_START_PAGE_URL = "/request-a-service-record/start/";
-  const SERVICE_BRANCH_URL = "/request-a-service-record/service-branch/";
-  const WAS_SERVICE_PERSON_OFFICER_URL =
-    "/request-a-service-record/was-service-person-officer/";
-  const MOD_HAVE_THIS_RECORD_URL = "/request-a-service-record/mod-have-this-record/";
-  const CHECK_ANCESTRY_URL = "/request-a-service-record/check-ancestry/";
+  const basePath = "/request-a-service-record";
+
+  enum Urls {
+    JOURNEY_START_PAGE = `${basePath}/start/`,
+    SERVICE_BRANCH = `${basePath}/service-branch/`,
+    WAS_SERVICE_PERSON_OFFICER = `${basePath}/was-service-person-officer/`,
+    MOD_HAVE_THIS_RECORD = `${basePath}/mod-have-this-record/`,
+    CHECK_ANCESTRY = `${basePath}/check-ancestry/`,
+  }
 
   test.beforeEach(async ({ page }) => {
-    await page.goto(JOURNEY_START_PAGE_URL); // We need to go here first because we prevent direct access to mid-journey pages
-    await page.goto(SERVICE_BRANCH_URL);
+    await page.goto(Urls.JOURNEY_START_PAGE); // We need to go here first because we prevent direct access to mid-journey pages
+    await page.goto(Urls.SERVICE_BRANCH);
   });
 
   test("Shows the correct heading", async ({ page }) => {
@@ -31,35 +34,35 @@ test.describe("What was the person's service branch?", () => {
   [
     {
       branchLabel: "British Army",
-      nextUrl: WAS_SERVICE_PERSON_OFFICER_URL,
+      nextUrl: Urls.WAS_SERVICE_PERSON_OFFICER,
       expectedHeading: /Was the service person an officer\?/,
     },
     {
       branchLabel: "Royal Navy",
-      nextUrl: MOD_HAVE_THIS_RECORD_URL,
+      nextUrl: Urls.MOD_HAVE_THIS_RECORD,
       expectedHeading: /The Ministry of Defence has this record/,
     },
     {
       branchLabel: "Royal Air Force",
-      nextUrl: WAS_SERVICE_PERSON_OFFICER_URL,
+      nextUrl: Urls.WAS_SERVICE_PERSON_OFFICER,
       expectedHeading: /Was the service person an officer\?/,
     },
     {
       branchLabel: "I don't know",
-      nextUrl: WAS_SERVICE_PERSON_OFFICER_URL,
+      nextUrl: Urls.WAS_SERVICE_PERSON_OFFICER,
       expectedHeading: /Was the service person an officer\?/,
     },
     {
       branchLabel: "Home Guard",
-      nextUrl: CHECK_ANCESTRY_URL,
+      nextUrl: Urls.CHECK_ANCESTRY,
       expectedHeading: /Check Ancestry/,
     },
   ].forEach(({ branchLabel, nextUrl, expectedHeading }) => {
     test(`Presents the correct form when ${branchLabel} is selected`, async ({
       page,
     }) => {
-      await page.goto(JOURNEY_START_PAGE_URL);
-      await page.goto(SERVICE_BRANCH_URL);
+      await page.goto(Urls.JOURNEY_START_PAGE);
+      await page.goto(Urls.SERVICE_BRANCH);
       await page.getByLabel(branchLabel, { exact: true }).check();
       await page.getByRole("button", { name: /Continue/i }).click();
       await expect(page).toHaveURL(nextUrl);

--- a/test/playwright/multi-page-journey/service-branch.spec.ts
+++ b/test/playwright/multi-page-journey/service-branch.spec.ts
@@ -1,0 +1,69 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("What was the person's service branch?", () => {
+  const JOURNEY_START_PAGE_URL = "/request-a-service-record/start/";
+  const SERVICE_BRANCH_URL = "/request-a-service-record/service-branch/";
+  const WAS_SERVICE_PERSON_OFFICER_URL =
+    "/request-a-service-record/was-service-person-officer/";
+  const MOD_HAVE_THIS_RECORD_URL = "/request-a-service-record/mod-have-this-record/";
+  const CHECK_ANCESTRY_URL = "/request-a-service-record/check-ancestry/";
+
+  test.beforeEach(async ({ page }) => {
+    await page.goto(JOURNEY_START_PAGE_URL); // We need to go here first because we prevent direct access to mid-journey pages
+    await page.goto(SERVICE_BRANCH_URL);
+  });
+
+  test("Shows the correct heading", async ({ page }) => {
+    await expect(page.locator("h1")).toHaveText(
+      /What was the person's service branch\?/,
+    );
+  });
+
+  test("Shows an error if no option is selected and the user clicks 'Continue'", async ({
+    page,
+  }) => {
+    await page.getByRole("button", { name: /Continue/i }).click();
+    await expect(page.locator(".tna-form__error-message")).toHaveText(
+      /The service person's service branch is required/,
+    );
+  });
+
+  [
+    {
+      branchLabel: "British Army",
+      nextUrl: WAS_SERVICE_PERSON_OFFICER_URL,
+      expectedHeading: /Was the service person an officer\?/,
+    },
+    {
+      branchLabel: "Royal Navy",
+      nextUrl: MOD_HAVE_THIS_RECORD_URL,
+      expectedHeading: /The Ministry of Defence has this record/,
+    },
+    {
+      branchLabel: "Royal Air Force",
+      nextUrl: WAS_SERVICE_PERSON_OFFICER_URL,
+      expectedHeading: /Was the service person an officer\?/,
+    },
+    {
+      branchLabel: "I don't know",
+      nextUrl: WAS_SERVICE_PERSON_OFFICER_URL,
+      expectedHeading: /Was the service person an officer\?/,
+    },
+    {
+      branchLabel: "Home Guard",
+      nextUrl: CHECK_ANCESTRY_URL,
+      expectedHeading: /Check Ancestry/,
+    },
+  ].forEach(({ branchLabel, nextUrl, expectedHeading }) => {
+    test(`Presents the correct form when ${branchLabel} is selected`, async ({
+      page,
+    }) => {
+      await page.goto(JOURNEY_START_PAGE_URL);
+      await page.goto(SERVICE_BRANCH_URL);
+      await page.getByLabel(branchLabel, { exact: true }).check();
+      await page.getByRole("button", { name: /Continue/i }).click();
+      await expect(page).toHaveURL(nextUrl);
+      await expect(page.locator("h1")).toHaveText(expectedHeading);
+    });
+  });
+});


### PR DESCRIPTION
The routing presented here reflects a conversation with the PM yesterday afternoon that set out where users should be directed. The commit includes:

1. Updating `state_machine.py` to include three new states reached via the service branch form
2. Comprehensive testing - including both additional tests added to `test_state_machine.py` for all options and Playwright tests for all onward routes from the service branch form
3. Updating `constants.py` to include the new routes and service branch options
4. Adding new templates and sections in `content.yaml` for the three new pages ("MOD have this record", "Check Ancestry" and "Was the service person an officer")

Copilot seems to like what I've done too, saying: 

> These changes are positive, well-organized, and improve the multi-page form’s routing and user guidance. They set a solid foundation for handling more complex user journeys and future content expansion.

❤️ 