### PR TITLE
FOI-71: Disambiguate (split) "We don't have" pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ An example event would be `continue_from_service_branch_form`
 ```python
 continue_from_service_branch_form = (
         initial.to(was_service_person_an_officer_form, unless="go_to_mod or likely_unfindable")
-        | initial.to(we_do_not_have_this_record_page, cond="go_to_mod")
+        | initial.to(we_do_not_have_records_for_this_service_branch_page, cond="go_to_mod")
         | initial.to(we_may_be_unable_to_find_this_record_page, cond="likely_unfindable")
 )
 ```

--- a/app/constants.py
+++ b/app/constants.py
@@ -11,7 +11,8 @@ class MultiPageFormRoutes(Enum):
         "main.only_living_subjects_can_request_their_record"
     )
     WAS_SERVICE_PERSON_AN_OFFICER_FORM = "main.was_service_person_an_officer"
-    WE_DO_NOT_HAVE_THIS_RECORD = "main.we_do_not_have_this_record"
+    WE_DO_NOT_HAVE_RECORDS_FOR_THIS_SERVICE_BRANCH = "main.we_do_not_have_records_for_this_service_branch"
+    WE_DO_NOT_HAVE_RECORDS_FOR_THIS_RANK = "main.we_do_not_have_records_for_this_rank"
     WE_MAY_BE_UNABLE_TO_FIND_THIS_RECORD = "main.we_may_be_unable_to_find_this_record"
     WE_MAY_HOLD_THIS_RECORD = "main.we_may_hold_this_record"
 

--- a/app/content/content.yaml
+++ b/app/content/content.yaml
@@ -71,8 +71,12 @@ pages:
       - |
         You will need to use our [INSERT NAME HERE] form to request your own Ministry of Defence (MOD) 
         service personnel record, or if you are acting on behalf of a living service personnel member.
-  we_do_not_have_this_record:
-    heading: We do not have this record
+  we_do_not_have_records_for_this_service_branch:
+    heading: We do not have records for this service branch
+    paragraphs:
+      - Sorry, but here is some helpful information
+  we_do_not_have_records_for_this_rank:
+    heading: We do not have records for this rank
     paragraphs:
       - Sorry, but here is some helpful information
   was_service_person_an_officer:

--- a/app/lib/state_machine/state_machine.py
+++ b/app/lib/state_machine/state_machine.py
@@ -47,8 +47,11 @@ class RoutingStateMachine(StateMachine):
     was_service_person_an_officer_form = State(
         enter="entering_was_service_person_an_officer_form", final=True
     )
-    we_do_not_have_this_record_page = State(
-        enter="entering_we_do_not_have_this_record", final=True
+    we_do_not_have_records_for_this_service_branch_page = State(
+        enter="entering_we_do_not_have_records_for_this_service_branch", final=True
+    )
+    we_do_not_have_records_for_this_rank_page = State(
+        enter="entering_we_do_not_have_records_for_this_rank_page", final=True
     )
     we_may_be_unable_to_find_this_record_page = State(
         enter="entering_we_may_be_unable_to_find_this_record_page", final=True
@@ -78,7 +81,7 @@ class RoutingStateMachine(StateMachine):
         initial.to(
             was_service_person_an_officer_form, unless="go_to_mod or likely_unfindable"
         )
-        | initial.to(we_do_not_have_this_record_page, cond="go_to_mod")
+        | initial.to(we_do_not_have_records_for_this_service_branch_page, cond="go_to_mod")
         | initial.to(
             we_may_be_unable_to_find_this_record_page, cond="likely_unfindable"
         )
@@ -86,7 +89,7 @@ class RoutingStateMachine(StateMachine):
 
     continue_from_was_service_person_an_officer_form = initial.to(
         we_may_hold_this_record_page, unless="was_officer"
-    ) | initial.to(we_do_not_have_this_record_page, cond="was_officer")
+    ) | initial.to(we_do_not_have_records_for_this_rank_page, cond="was_officer")
 
     def entering_have_you_checked_the_catalogue_form(self, event, state):
         self.route_for_current_state = (
@@ -117,9 +120,14 @@ class RoutingStateMachine(StateMachine):
             MultiPageFormRoutes.WAS_SERVICE_PERSON_AN_OFFICER_FORM.value
         )
 
-    def entering_we_do_not_have_this_record(self, form):
+    def entering_we_do_not_have_records_for_this_service_branch(self, form):
         self.route_for_current_state = (
-            MultiPageFormRoutes.WE_DO_NOT_HAVE_THIS_RECORD.value
+            MultiPageFormRoutes.WE_DO_NOT_HAVE_RECORDS_FOR_THIS_SERVICE_BRANCH.value
+        )
+
+    def entering_we_do_not_have_records_for_this_rank_page(self, form):
+        self.route_for_current_state = (
+            MultiPageFormRoutes.WE_DO_NOT_HAVE_RECORDS_FOR_THIS_RANK.value
         )
 
     def entering_we_may_be_unable_to_find_this_record_page(self, form):

--- a/app/main/routes/routes_multiple_forms_journey.py
+++ b/app/main/routes/routes_multiple_forms_journey.py
@@ -118,10 +118,18 @@ def search_the_catalogue():
     )
 
 
-@bp.route("/we-do-not-have-this-record/", methods=["GET"])
-def we_do_not_have_this_record():
+@bp.route("/we-do-not-have-records-for-this-service-branch/", methods=["GET"])
+def we_do_not_have_records_for_this_service_branch():
     return render_template(
-        "main/multi-page-journey/we-do-not-have-this-record.html",
+        "main/multi-page-journey/we-do-not-have-records-for-this-service-branch.html",
+        content=load_content(),
+    )
+
+
+@bp.route("/we-do-not-have-records-for-this-rank/", methods=["GET"])
+def we_do_not_have_records_for_this_rank():
+    return render_template(
+        "main/multi-page-journey/we-do-not-have-records-for-this-rank.html",
         content=load_content(),
     )
 

--- a/app/templates/main/multi-page-journey/we-do-not-have-records-for-this-rank.html
+++ b/app/templates/main/multi-page-journey/we-do-not-have-records-for-this-rank.html
@@ -1,0 +1,17 @@
+{% extends 'base.html' %}
+
+{%- set pageTitle = content.app.title -%}
+
+{% block content %}
+  <div class="tna-section">
+    <div class="tna-container">
+      <div
+        class="tna-column tna-column--width-2-3 tna-column--width-5-6-medium tna-column--full-small tna-column--full-tiny">
+        <h1 class="tna-heading-xl">{{ content.pages.we_do_not_have_records_for_this_rank.heading }}</h1>
+        {% for paragraph in content.pages.we_do_not_have_records_for_this_rank.paragraphs %}
+          <p>{{ paragraph }}</p>
+        {% endfor %}
+      </div>
+    </div>
+  </div>
+{% endblock %}

--- a/app/templates/main/multi-page-journey/we-do-not-have-records-for-this-service-branch.html
+++ b/app/templates/main/multi-page-journey/we-do-not-have-records-for-this-service-branch.html
@@ -7,8 +7,8 @@
     <div class="tna-container">
       <div
         class="tna-column tna-column--width-2-3 tna-column--width-5-6-medium tna-column--full-small tna-column--full-tiny">
-        <h1 class="tna-heading-xl">{{ content.pages.we_do_not_have_this_record.heading }}</h1>
-        {% for paragraph in content.pages.we_do_not_have_this_record.paragraphs %}
+        <h1 class="tna-heading-xl">{{ content.pages.we_do_not_have_records_for_this_service_branch.heading }}</h1>
+        {% for paragraph in content.pages.we_do_not_have_records_for_this_service_branch.paragraphs %}
           <p>{{ paragraph }}</p>
         {% endfor %}
       </div>

--- a/test/main/test_state_machine.py
+++ b/test/main/test_state_machine.py
@@ -78,8 +78,8 @@ def test_continue_from_service_person_alive_form_routes_by_condition(
         ),
         (
             "ROYAL_NAVY",
-            "we_do_not_have_this_record_page",
-            MultiPageFormRoutes.WE_DO_NOT_HAVE_THIS_RECORD.value,
+            "we_do_not_have_records_for_this_service_branch_page",
+            MultiPageFormRoutes.WE_DO_NOT_HAVE_RECORDS_FOR_THIS_SERVICE_BRANCH.value,
         ),
         (
             "HOME_GUARD",
@@ -127,8 +127,8 @@ def test_continue_from_service_branch_form_routes_by_condition(
         ),
         (
             "yes",
-            "we_do_not_have_this_record_page",
-            MultiPageFormRoutes.WE_DO_NOT_HAVE_THIS_RECORD.value,
+            "we_do_not_have_records_for_this_rank_page",
+            MultiPageFormRoutes.WE_DO_NOT_HAVE_RECORDS_FOR_THIS_RANK.value,
         ),
     ],
 )

--- a/test/playwright/multi-page-journey/service-branch.spec.ts
+++ b/test/playwright/multi-page-journey/service-branch.spec.ts
@@ -7,7 +7,7 @@ test.describe("the 'What was the person's service branch?' form", () => {
     JOURNEY_START_PAGE = `${basePath}/start/`,
     SERVICE_BRANCH = `${basePath}/service-branch/`,
     WAS_SERVICE_PERSON_AN_OFFICER = `${basePath}/was-service-person-officer/`,
-    WE_DO_NOT_HAVE_THIS_RECORD = `${basePath}/we-do-not-have-this-record/`,
+    WE_DO_NOT_HAVE_RECORDS_FOR_THIS_SERVICE_BRANCH = `${basePath}/we-do-not-have-records-for-this-service-branch/`,
     WE_MAY_BE_UNABLE_TO_FIND_THIS_RECORD = `${basePath}/we-may-be-unable-to-find-this-record/`,
   }
 
@@ -20,8 +20,8 @@ test.describe("the 'What was the person's service branch?' form", () => {
     },
     {
       branchLabel: "Royal Navy",
-      nextUrl: Urls.WE_DO_NOT_HAVE_THIS_RECORD,
-      expectedHeading: /We do not have this record/,
+      nextUrl: Urls.WE_DO_NOT_HAVE_RECORDS_FOR_THIS_SERVICE_BRANCH,
+      expectedHeading: /We do not have records for this service branch/,
       destinationPageHasBackLink: false,
     },
     {

--- a/test/playwright/multi-page-journey/was-the-service-person-an-officer.spec.ts
+++ b/test/playwright/multi-page-journey/was-the-service-person-an-officer.spec.ts
@@ -6,7 +6,7 @@ test.describe("the 'Were they a commissioned officer?' form", () => {
   enum Urls {
     JOURNEY_START_PAGE = `${basePath}/start/`,
     WAS_SERVICE_PERSON_AN_OFFICER = `${basePath}/was-service-person-officer/`,
-    WE_DO_NOT_HAVE_THIS_RECORD = `${basePath}/we-do-not-have-this-record/`,
+    WE_DO_NOT_HAVE_RECORDS_FOR_THIS_RANK = `${basePath}/we-do-not-have-records-for-this-rank/`,
     WE_MAY_HOLD_THIS_RECORD = `${basePath}/we-may-hold-this-record/`,
   }
 
@@ -32,10 +32,10 @@ test.describe("the 'Were they a commissioned officer?' form", () => {
     const selectionMappings = [
       {
         branchLabel: "Yes",
-        nextUrl: Urls.WE_DO_NOT_HAVE_THIS_RECORD,
-        heading: /We do not have this record/,
+        nextUrl: Urls.WE_DO_NOT_HAVE_RECORDS_FOR_THIS_RANK,
+        heading: /We do not have records for this rank/,
         description:
-          "when 'Yes' is selected, presents the 'We do not have this record' page ",
+          "when 'Yes' is selected, presents the 'We do not have records for this rank' page ",
         destinationPageHasBackLink: false,
       },
       {


### PR DESCRIPTION
Prior to this commit, one template and route was being used for both:

1. We don't have records for this service branch
2. We don't have records for this rank

Looking at version 1.2 of the user flow, there are additional variants and I feel there's a strong likelihood these pages will need content specific to the relevant journey. I've therefore decided to split them out so that we have different templates and tests.