### PR TITLE
Restore README.md to version containing env vars and quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,38 +1,77 @@
-# Request a service record
+# TNA Python Flask Application
 
-> [!TIP]
-> This project was generated from the [TNA Flask Template](https://github.com/nationalarchives/flask-application-template), so you'll find the setup information in its README.
+## Quickstart
 
-## Overview
-
-New approaches used in this service are:
-
-- the use of a state machine to determine a user's next step in the process
-- the use of a single YAML file to hold all page and form content
-
-## The state machine
-
-This application uses the [Python StateMachine](https://pypi.org/project/python-statemachine/) library under the MIT licence to implement a state machine. The state machine comprises:
-
-- **States** - representing a page or form in the service. Each state has data attached to it, such as the `_route_for_current_state`
-- **Events** - representing a transition from one state to another, sometimes with conditions attached.
-
-An example state would be `have_you_checked_the_catalogue_form`:
-
-```python
-have_you_checked_the_catalogue_form = State(enter="entering_have_you_checked_the_catalogue_form", final=True)
+```sh
+# Build and start the container
+docker compose up -d
 ```
 
-This is a final state, meaning that once the user reaches this state they cannot transition to any other state. The `enter` parameter specifies a method to be called when the state is entered.
+### Add the static assets
 
-An example event would be `continue_from_service_branch_form`
+During the first time install, your `app/static/assets` directory will be empty.
 
-```python
-continue_from_service_branch_form = (
-        initial.to(was_service_person_an_officer_form, unless="go_to_mod or likely_unfindable")
-        | initial.to(we_do_not_have_records_for_this_service_branch_page, cond="go_to_mod")
-        | initial.to(we_may_be_unable_to_find_this_record_page, cond="likely_unfindable")
-)
+As you mount the project directory to the `/app` volume, the static assets from TNA Frontend installed inside the container will be "overwritten" by your empty directory.
+
+To add back in the static assets, run:
+
+```sh
+docker compose exec app cp -r /app/node_modules/@nationalarchives/frontend/nationalarchives/assets /app/app/static
 ```
 
-Here we're saying that there are three possible transitions in response to this event, all of which correspond to what is returned by the conditions.
+### Run tests
+
+```sh
+docker compose exec dev poetry run python -m pytest
+```
+
+### Format and lint code
+
+```sh
+docker compose exec dev format
+```
+
+## Environment variables
+
+In addition to the [base Docker image variables](https://github.com/nationalarchives/docker/blob/main/docker/tna-python/README.md#environment-variables), this application has support for:
+
+| Variable                         | Purpose                                                                     | Default                                                   |
+| -------------------------------- | --------------------------------------------------------------------------- | --------------------------------------------------------- |
+| `CONFIG`                         | The configuration to use                                                    | `config.Production`                                       |
+| `DEBUG`                          | If true, allow debugging[^1]                                                | `False`                                                   |
+| `COOKIE_DOMAIN`                  | The domain to save cookie preferences against                               | _none_                                                    |
+| `CSP_IMG_SRC`                    | A comma separated list of CSP rules for `img-src`                           | `'self'`                                                  |
+| `CSP_SCRIPT_SRC`                 | A comma separated list of CSP rules for `script-src`                        | `'self'`                                                  |
+| `CSP_STYLE_SRC`                  | A comma separated list of CSP rules for `style-src`                         | `'self'`                                                  |
+| `CSP_FONT_SRC`                   | A comma separated list of CSP rules for `font-src`                          | `'self'`                                                  |
+| `CSP_CONNECT_SRC`                | A comma separated list of CSP rules for `connect-src`                       | `'self'`                                                  |
+| `CSP_MEDIA_SRC`                  | A comma separated list of CSP rules for `media-src`                         | `'self'`                                                  |
+| `CSP_WORKER_SRC`                 | A comma separated list of CSP rules for `worker-src`                        | `'self'`                                                  |
+| `CSP_FRAME_SRC`                  | A comma separated list of CSP rules for `frame-src`                         | `'self'`                                                  |
+| `CSP_FEATURE_FULLSCREEN`         | A comma separated list of rules for the `fullscreen` feature policy         | `'self'`                                                  |
+| `CSP_FEATURE_PICTURE_IN_PICTURE` | A comma separated list of rules for the `picture-in-picture` feature policy | `'self'`                                                  |
+| `FORCE_HTTPS`                    | Redirect requests to HTTPS as part of the CSP                               | _none_                                                    |
+| `CACHE_TYPE`                     | https://flask-caching.readthedocs.io/en/latest/#configuring-flask-caching   | _none_                                                    |
+| `CACHE_DEFAULT_TIMEOUT`          | The number of seconds to cache pages for                                    | production: `300`, staging: `60`, develop: `0`, test: `0` |
+| `CACHE_DIR`                      | Directory for storing cached responses when using `FileSystemCache`         | `/tmp`                                                    |
+| `GA4_ID`                         | The Google Analytics 4 ID                                                   | _none_                                                    |
+| `GOV_UK_PAY_API_KEY`             | GOV.UK Pay API key                                                          | _none_ (required for payments)                            |
+| `GOV_UK_PAY_API_URL`             | GOV.UK Pay create payment endpoint URL                                      | _none_ (required for payments)                            |
+| `GOV_UK_PAY_SIGNING_SECRET`      | GOV.UK Pay webhook HMAC signing secret                                      | _none_ (required for webhooks)                            |
+| `SQLALCHEMY_DATABASE_URI`        | SQLAlchemy database connection string                                       | _none_ (required)                                         |
+| `SQLALCHEMY_TRACK_MODIFICATIONS` | SQLAlchemy event system toggle                                              | `False`                                                   |
+| `REDIS_HOST`                     | Redis host for sessions/cache                                               | _none_                                                    |
+| `REDIS_PORT`                     | Redis port                                                                  | `6379`                                                    |
+| `REDIS_DB`                       | Redis database index                                                        | `0`                                                       |
+| `REDIS_USERNAME`                 | Redis username                                                              | _none_                                                    |
+| `REDIS_PASSWORD`                 | Redis password                                                              | _none_                                                    |
+| `AWS_ACCESS_KEY_ID`              | AWS access key                                                              | _none_                                                    |
+| `AWS_SECRET_ACCESS_KEY`          | AWS secret key                                                              | _none_                                                    |
+| `AWS_SESSION_TOKEN`              | AWS session token                                                           | _none_                                                    |
+| `AWS_DEFAULT_REGION`             | AWS region for clients (SES/S3)                                             | _none_                                                    |
+| `PROOF_OF_DEATH_BUCKET_NAME`     | S3 bucket location for uploaded proof-of-death files                        | _none_ (required for file uploads)                        |
+| `MAX_UPLOAD_ATTEMPTS`            | Number of retry attempts for S3 uploads                                     | `3`                                                       |
+| `EMAIL_FROM`                     | The address which SES will send emails from                                 | _none_                                                    |
+| `DYNAMICS_INBOX`                 | The address which SES will send Dynamics emails to                          | _none_                                                    |
+
+[^1] [Debugging in Flask](https://flask.palletsprojects.com/en/2.3.x/debugging/)


### PR DESCRIPTION
I've been asked by the Lead Frontend Developer today to restore these sections to the README because they needed. They also suggested moving documentation about the state machine to a `/docs` repo, which I will do in a later PR. 