### PR TITLE
FOI-73: Populate pages that follow "What was their date of birth?"

### DIFF
--- a/app/constants.py
+++ b/app/constants.py
@@ -25,7 +25,7 @@ class MultiPageFormRoutes(Enum):
         "main.we_do_not_have_records_for_people_born_after"
     )
     SERVICE_PERSON_DETAILS = "main.service_person_details"
-    DO_YOU_HAVE_TO_PROVIDE_PROOF_OF_DEATH = "main.do_you_have_to_provide_proof_of_death"
+    DO_YOU_HAVE_A_PROOF_OF_DEATH = "main.do_you_have_a_proof_of_death_form"
 
 
 class ServiceBranches(Enum):

--- a/app/content/content.yaml
+++ b/app/content/content.yaml
@@ -84,9 +84,10 @@ pages:
     paragraphs:
       - Sorry, but here is some helpful information
   we_do_not_have_records_for_people_born_after:
-    heading: We do not have records for people born after 1939
+    heading: We do not have this record
     paragraphs:
-      - Sorry, but here is some helpful information
+      - You will need to request the service record from the Ministry of Defence.
+    call_to_action: Apply for MOD records
   was_service_person_an_officer:
     heading: Were they a commissioned officer?
     paragraphs:
@@ -116,10 +117,17 @@ pages:
     heading: Service person details
     paragraphs:
       - Service person details content to go here
-  do_you_have_to_provide_proof_of_death:
+  do_you_have_a_proof_of_death_form:
     heading: Provide a proof of death
     paragraphs:
-      - Proof of death content to go here
+      - You will need to upload a digital copy of a proof of death for the service person.
+      - >
+        Suitable forms of evidence include:
+    list_items:
+      - "[copies of death certificates](https://www.gov.uk/order-copy-birth-death-marriage-certificate)"
+      - published obituaries (detailing publication source, name of deceased, and date of birth and death)
+      - "[war dead records](https://www.cwgc.org/find-records/find-war-dead/)"
+    warning: If you do not send a proof of death when required, it is likely that we will withold all of the requested information and cannot provide the record.
   all_fields_in_one_form:
     service_person_details:
       legend: Service person detail

--- a/app/lib/state_machine/state_machine.py
+++ b/app/lib/state_machine/state_machine.py
@@ -193,9 +193,7 @@ class RoutingStateMachine(StateMachine):
         )
 
     def entering_do_you_have_a_proof_of_death_form(self, form):
-        self.route_for_current_state = (
-            MultiPageFormRoutes.DO_YOU_HAVE_TO_PROVIDE_PROOF_OF_DEATH.value
-        )
+        self.route_for_current_state = MultiPageFormRoutes.DO_YOU_HAVE_A_PROOF_OF_DEATH.value
 
     def on_enter_state(self, event, state):
         """This method is called when entering any state."""

--- a/app/main/routes/routes_multiple_forms_journey.py
+++ b/app/main/routes/routes_multiple_forms_journey.py
@@ -191,9 +191,8 @@ def service_person_details():
         "main/multi-page-journey/service-person-details.html", content=load_content()
     )
 
-
-@bp.route("/do-you-have-to-provide-a-proof-of-death/", methods=["GET"])
-def do_you_have_to_provide_proof_of_death():
+@bp.route("/do-you-have-a-proof-of-death/", methods=["GET"])
+def do_you_have_a_proof_of_death_form():
     return render_template(
         "main/multi-page-journey/do-you-have-a-proof-of-death.html",
         content=load_content(),

--- a/app/templates/main/multi-page-journey/do-you-have-a-proof-of-death.html
+++ b/app/templates/main/multi-page-journey/do-you-have-a-proof-of-death.html
@@ -7,10 +7,27 @@
     <div class="tna-container">
       <div
         class="tna-column tna-column--width-2-3 tna-column--width-5-6-medium tna-column--full-small tna-column--full-tiny">
-        <h1 class="tna-heading-xl">{{ content.pages.do_you_have_to_provide_proof_of_death.heading }}</h1>
-        {% for paragraph in content.pages.do_you_have_to_provide_proof_of_death.paragraphs %}
+        <h1 class="tna-heading-xl">{{ content.pages.do_you_have_a_proof_of_death_form.heading }}</h1>
+        {% for paragraph in content.pages.do_you_have_a_proof_of_death_form.paragraphs %}
           <p>{{ paragraph }}</p>
         {% endfor %}
+        <ul class="tna-ul">
+          {% for item in content.pages.do_you_have_a_proof_of_death_form.list_items %}
+            <li>{{ item | parse_markdown_links | safe }}</li>
+          {% endfor %}
+        </ul>
+        <div class="tna-warning">
+          <h2 class="tna-warning__heading">
+            <span class="tna-visually-hidden">Important information</span><span class="tna-warning__heading-icon"
+                                                                                aria-hidden="true">!</span>
+          </h2>
+          <div class="tna-warning__body">
+            {{ content.pages.do_you_have_a_proof_of_death_form.warning }}
+          </div>
+        </div>
+        <div class="tna-button-group">
+          {{ back_link(url_for('main.what_was_their_date_of_birth')) }}
+        </div>
       </div>
     </div>
   </div>

--- a/app/templates/main/multi-page-journey/we-do-not-have-records-for-people-born-after.html
+++ b/app/templates/main/multi-page-journey/we-do-not-have-records-for-people-born-after.html
@@ -11,6 +11,12 @@
         {% for paragraph in content.pages.we_do_not_have_records_for_people_born_after.paragraphs %}
           <p>{{ paragraph }}</p>
         {% endfor %}
+        <div class="tna-button-group">
+          <a href="https://www.gov.uk/get-copy-military-records-of-service" class="tna-button tna-button--accent">
+            {{ content.pages.we_do_not_have_records_for_people_born_after.call_to_action }}
+            <i class="fa-solid fa-arrow-right" aria-hidden="true"></i>
+          </a>
+        </div>
       </div>
     </div>
   </div>

--- a/test/main/test_state_machine.py
+++ b/test/main/test_state_machine.py
@@ -204,7 +204,7 @@ def test_continue_from_we_may_hold_this_record():
         (
             date(year, 1, 1),
             "do_you_have_a_proof_of_death_form",
-            MultiPageFormRoutes.DO_YOU_HAVE_TO_PROVIDE_PROOF_OF_DEATH.value,
+            MultiPageFormRoutes.DO_YOU_HAVE_A_PROOF_OF_DEATH.value,
         )
         for year in range(1911, 1939)
     ],

--- a/test/playwright/multi-page-journey/do-you-have-a-proof-of-death.spec.ts
+++ b/test/playwright/multi-page-journey/do-you-have-a-proof-of-death.spec.ts
@@ -1,0 +1,19 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("The 'Do you have a proof of death?' form", () => {
+  const basePath = "/request-a-service-record";
+
+  enum Urls {
+    JOURNEY_START = `${basePath}/start/`,
+    DO_YOU_HAVE_A_PROOF_OF_DEATH = `${basePath}/do-you-have-a-proof-of-death`,
+  }
+
+  test.beforeEach(async ({ page }) => {
+    await page.goto(Urls.JOURNEY_START);
+    await page.goto(Urls.DO_YOU_HAVE_A_PROOF_OF_DEATH);
+  });
+
+  test("has the correct heading", async ({ page }) => {
+    await expect(page.locator("h1")).toHaveText(/Provide a proof of death/);
+  });
+});

--- a/test/playwright/multi-page-journey/what-was-their-date-of-birth.spec.ts
+++ b/test/playwright/multi-page-journey/what-was-their-date-of-birth.spec.ts
@@ -9,7 +9,7 @@ test.describe("the 'What was their date of birth?' form", () => {
     SERVICE_PERSON_DETAILS = `${basePath}/service-person-details/`,
     WE_DO_NOT_HAVE_RECORDS_FOR_PEOPLE_BORN_BEFORE = `${basePath}/we-do-not-have-records-for-people-born-before/`,
     WE_DO_NOT_HAVE_RECORDS_FOR_PEOPLE_BORN_AFTER = `${basePath}/we-do-not-have-records-for-people-born-after/`,
-    DO_YOU_HAVE_TO_PROVIDE_PROOF_OF_DEATH = `${basePath}/do-you-have-to-provide-a-proof-of-death/`,
+    DO_YOU_HAVE_A_PROOF_OF_DEATH = `${basePath}/do-you-have-a-proof-of-death/`,
   }
 
   test.beforeEach(async ({ page }) => {
@@ -80,7 +80,7 @@ test.describe("the 'What was their date of birth?' form", () => {
           nextUrl: Urls.SERVICE_PERSON_DETAILS,
           heading: /Service person details/,
           description:
-            "when the year of birth is 1890, the 'Service person details' page is shown",
+            "when the year of birth is 1890, the 'Service person details' page is shown and any 'Back' links work as expected",
         },
         {
           month: "01",
@@ -89,25 +89,25 @@ test.describe("the 'What was their date of birth?' form", () => {
           nextUrl: Urls.WE_DO_NOT_HAVE_RECORDS_FOR_PEOPLE_BORN_BEFORE,
           heading: /We do not have records for people born before/,
           description:
-            "when the year of birth is 1690, the 'We do not have records for people born before' page is shown",
+            "when the year of birth is 1690, the 'We do not have records for people born before' page is shown and any 'Back' links work as expected",
         },
         {
           month: "01",
           day: "01",
           year: "1950",
           nextUrl: Urls.WE_DO_NOT_HAVE_RECORDS_FOR_PEOPLE_BORN_AFTER,
-          heading: /We do not have records for people born after/,
+          heading: /We do not have this record/,
           description:
-            "when the year of birth is 1950, the 'We do not have records for people born after' page is shown",
+            "when the year of birth is 1950, the 'We do not have this record' page is shown and any 'Back' links work as expected",
         },
         {
           month: "01",
           day: "01",
           year: "1925",
-          nextUrl: Urls.DO_YOU_HAVE_TO_PROVIDE_PROOF_OF_DEATH,
+          nextUrl: Urls.DO_YOU_HAVE_A_PROOF_OF_DEATH,
           heading: /Provide a proof of death/,
           description:
-            "when the year of birth is 1925, the 'Provide proof of death' page is shown",
+            "when the year of birth is 1925, the 'Provide proof of death' page is shown and any 'Back' links work as expected",
         },
       ];
 
@@ -120,6 +120,12 @@ test.describe("the 'What was their date of birth?' form", () => {
             await page.getByRole("button", { name: /Continue/i }).click();
             await expect(page).toHaveURL(nextUrl);
             await expect(page.locator("h1")).toHaveText(heading);
+            const backLink = page.getByRole("link", { name: "Back" });
+            // If there's a "Back" link, click it
+            if ((await backLink.count()) > 0) {
+              await backLink.click();
+              await expect(page).toHaveURL(Urls.WHAT_WAS_THEIR_DATE_OF_BIRTH);
+            }
           });
         },
       );


### PR DESCRIPTION
Populates the pages that follow date of birth entry using YAML content:

- [x] We do not have this record (born before 1800)
- [x] You must request this from MOD (born after 1939)
- [x] Provide a proof of death

Note: this does not include the forms on "Provide a proof of death" and "About the service person" - these will be picked up in separate tickets