### PR TITLE
FOI-76: Create "Upload proof of death" form

### DIFF
--- a/app/constants.py
+++ b/app/constants.py
@@ -25,7 +25,8 @@ class MultiPageFormRoutes(Enum):
         "main.we_do_not_have_records_for_people_born_after"
     )
     SERVICE_PERSON_DETAILS = "main.service_person_details"
-    DO_YOU_HAVE_A_PROOF_OF_DEATH = "main.do_you_have_a_proof_of_death_form"
+    DO_YOU_HAVE_A_PROOF_OF_DEATH = "main.do_you_have_a_proof_of_death"
+    UPLOAD_A_PROOF_OF_DEATH = "main.upload_a_proof_of_death"
 
 
 class ServiceBranches(Enum):

--- a/app/content/content.yaml
+++ b/app/content/content.yaml
@@ -113,11 +113,20 @@ pages:
       - payment - you will need a debit or credit card
     paragraphs_after_list:
       - By completing this form you are requesting information from a UK public authority, The National Archives. We are therefore required to treat it as a Freedom of Information (FOI) request. [You can find out more about FOI on GOV.UK](https://www.gov.uk/make-a-freedom-of-information-request).
+  upload_a_proof_of_death:
+    heading: Upload a proof of death
+    paragraphs:
+      - >
+        The file must be:
+    list_items:
+      - JPG, PNG or PDF
+      - no more than 5MB
+      - clear and show all the death certificate
   service_person_details:
     heading: Service person details
     paragraphs:
       - Service person details content to go here
-  do_you_have_a_proof_of_death_form:
+  do_you_have_a_proof_of_death:
     heading: Provide a proof of death
     paragraphs:
       - You will need to upload a digital copy of a proof of death for the service person.
@@ -221,6 +230,13 @@ forms:
       label: Do you have a proof of death?
       messages:
         required: Choosing an option is required
+      call_to_action: Continue
+    upload_a_proof_of_death:
+      label: Upload a file
+      messages:
+        required: Uploading a file is required
+        file_size: The maximum file size is 5MB
+        file_allowed: Files must be in JPG, PNG or PDF format
       call_to_action: Continue
     service_number:
       label: Service number (optional)

--- a/app/lib/state_machine/state_machine.py
+++ b/app/lib/state_machine/state_machine.py
@@ -74,6 +74,9 @@ class RoutingStateMachine(StateMachine):
     do_you_have_a_proof_of_death_form = State(
         enter="entering_do_you_have_a_proof_of_death_form", final=True
     )
+    upload_a_proof_of_death_form = State(
+        enter="entering_upload_a_proof_of_death_form", final=True
+    )
 
     """
     These are our Events. They're called in route methods to trigger transitions between States.
@@ -125,6 +128,10 @@ class RoutingStateMachine(StateMachine):
         | initial.to(
             do_you_have_a_proof_of_death_form, cond="birth_year_requires_proof_of_death"
         )
+    )
+
+    continue_from_do_you_have_a_proof_of_death_form = initial.to(
+        upload_a_proof_of_death_form
     )
 
     def entering_have_you_checked_the_catalogue_form(self, event, state):
@@ -193,7 +200,12 @@ class RoutingStateMachine(StateMachine):
         )
 
     def entering_do_you_have_a_proof_of_death_form(self, form):
-        self.route_for_current_state = MultiPageFormRoutes.DO_YOU_HAVE_A_PROOF_OF_DEATH.value
+        self.route_for_current_state = (
+            MultiPageFormRoutes.DO_YOU_HAVE_A_PROOF_OF_DEATH.value
+        )
+
+    def entering_upload_a_proof_of_death_form(self, form):
+        self.route_for_current_state = MultiPageFormRoutes.UPLOAD_A_PROOF_OF_DEATH.value
 
     def on_enter_state(self, event, state):
         """This method is called when entering any state."""

--- a/app/main/forms/do_you_have_a_proof_of_death.py
+++ b/app/main/forms/do_you_have_a_proof_of_death.py
@@ -21,4 +21,7 @@ class DoYouHaveAProofOfDeath(FlaskForm):
         widget=TnaRadiosWidget(),
     )
 
-    submit = SubmitField(get_field_content(content, "do_you_have_a_proof_of_death", "call_to_action"), widget=TnaSubmitWidget())
+    submit = SubmitField(
+        get_field_content(content, "do_you_have_a_proof_of_death", "call_to_action"),
+        widget=TnaSubmitWidget(),
+    )

--- a/app/main/forms/upload_a_proof_of_death.py
+++ b/app/main/forms/upload_a_proof_of_death.py
@@ -1,0 +1,43 @@
+from app.lib.content import get_field_content, load_content
+from flask_wtf import FlaskForm
+from flask_wtf.file import FileAllowed, FileSize
+from tna_frontend_jinja.wtforms import TnaDroppableFileInputWidget, TnaSubmitWidget
+from tna_frontend_jinja.wtforms import validators as tna_frontend_validators
+from wtforms import (
+    FileField,
+    SubmitField,
+)
+from wtforms.validators import InputRequired
+
+
+class UploadAProofOfDeath(FlaskForm):
+    content = load_content()
+
+    proof_of_death = FileField(
+        get_field_content(content, "upload_a_proof_of_death", "label"),
+        validators=[
+            InputRequired(
+                message=get_field_content(
+                    content, "upload_a_proof_of_death", "messages"
+                )["required"]
+            ),
+            FileAllowed(
+                upload_set=["jpg", "png", "pdf"],
+                message=get_field_content(
+                    content, "upload_a_proof_of_death", "messages"
+                )["file_allowed"],
+            ),
+            FileSize(
+                max_size=5 * 1024 * 1024,
+                message=get_field_content(
+                    content, "upload_a_proof_of_death", "messages"
+                )["file_size"],
+            ),
+        ],
+        widget=TnaDroppableFileInputWidget(),
+    )
+
+    submit = SubmitField(
+        get_field_content(content, "upload_a_proof_of_death", "call_to_action"),
+        widget=TnaSubmitWidget(),
+    )

--- a/app/main/routes/routes_multiple_forms_journey.py
+++ b/app/main/routes/routes_multiple_forms_journey.py
@@ -12,6 +12,7 @@ from app.main.forms.start_now import StartNow
 from app.main.forms.was_service_person_an_officer import WasServicePersonAnOfficer
 from app.main.forms.we_may_hold_this_record import WeMayHoldThisRecord
 from app.main.forms.what_was_their_date_of_birth import WhatWasTheirDateOfBirth
+from app.main.forms.upload_a_proof_of_death import UploadAProofOfDeath
 from flask import redirect, render_template, session, url_for
 
 
@@ -192,14 +193,30 @@ def service_person_details():
         "main/multi-page-journey/service-person-details.html", content=load_content()
     )
 
+
 @bp.route("/do-you-have-a-proof-of-death/", methods=["GET", "POST"])
 @with_form_prefilled_from_session(DoYouHaveAProofOfDeath)
 @with_state_machine
-def do_you_have_a_proof_of_death_form(form, state_machine):
+def do_you_have_a_proof_of_death(form, state_machine):
     if form.validate_on_submit():
-        pass
+        session["do_you_have_a_proof_of_death"] = form.do_you_have_a_proof_of_death.data
+        state_machine.continue_from_do_you_have_a_proof_of_death_form(form)
+        return redirect(url_for(state_machine.route_for_current_state))
     return render_template(
         "main/multi-page-journey/do-you-have-a-proof-of-death.html",
+        form=form,
+        content=load_content(),
+    )
+
+
+@bp.route("/upload-a-proof-of-death/", methods=["GET", "POST"])
+@with_form_prefilled_from_session(UploadAProofOfDeath)
+@with_state_machine
+def upload_a_proof_of_death(form, state_machine):
+    if form.validate_on_submit():
+        return redirect(url_for("main.service_person_details"))
+    return render_template(
+        "main/multi-page-journey/upload-a-proof-of-death.html",
         form=form,
         content=load_content(),
     )

--- a/app/templates/main/multi-page-journey/do-you-have-a-proof-of-death.html
+++ b/app/templates/main/multi-page-journey/do-you-have-a-proof-of-death.html
@@ -7,12 +7,12 @@
     <div class="tna-container">
       <div
         class="tna-column tna-column--width-2-3 tna-column--width-5-6-medium tna-column--full-small tna-column--full-tiny">
-        <h1 class="tna-heading-xl">{{ content.pages.do_you_have_a_proof_of_death_form.heading }}</h1>
-        {% for paragraph in content.pages.do_you_have_a_proof_of_death_form.paragraphs %}
+        <h1 class="tna-heading-xl">{{ content.pages.do_you_have_a_proof_of_death.heading }}</h1>
+        {% for paragraph in content.pages.do_you_have_a_proof_of_death.paragraphs %}
           <p>{{ paragraph }}</p>
         {% endfor %}
         <ul class="tna-ul">
-          {% for item in content.pages.do_you_have_a_proof_of_death_form.list_items %}
+          {% for item in content.pages.do_you_have_a_proof_of_death.list_items %}
             <li>{{ item | parse_markdown_links | safe }}</li>
           {% endfor %}
         </ul>
@@ -22,10 +22,10 @@
                                                                                 aria-hidden="true">!</span>
           </h2>
           <div class="tna-warning__body">
-            {{ content.pages.do_you_have_a_proof_of_death_form.warning }}
+            {{ content.pages.do_you_have_a_proof_of_death.warning }}
           </div>
         </div>
-        <form action="{{ url_for('main.do_you_have_a_proof_of_death_form') }}" method="post" novalidate>
+        <form action="{{ url_for('main.do_you_have_a_proof_of_death') }}" method="post" novalidate>
           {{ form.csrf_token }}
           {{ form.do_you_have_a_proof_of_death(params={'headingLevel':2, 'headingSize':'l'}) }}
           <div class="tna-button-group">

--- a/app/templates/main/multi-page-journey/upload-a-proof-of-death.html
+++ b/app/templates/main/multi-page-journey/upload-a-proof-of-death.html
@@ -1,0 +1,29 @@
+{% extends 'base.html' %}
+
+{%- set pageTitle = content.app.title -%}
+
+{% block content %}
+  <div class="tna-section">
+    <div class="tna-container">
+      <div
+        class="tna-column tna-column--width-2-3 tna-column--width-5-6-medium tna-column--full-small tna-column--full-tiny">
+        <h1 class="tna-heading-xl">{{ content.pages.upload_a_proof_of_death.heading }}</h1>
+        {% for paragraph in content.pages.upload_a_proof_of_death.paragraphs %}
+          <p>{{ paragraph }}</p>
+        {% endfor %}
+        <ul class="tna-ul">
+          {% for item in content.pages.upload_a_proof_of_death.list_items %}
+            <li>{{ item }}</li>
+          {% endfor %}
+        </ul>
+        <form action="{{ url_for('main.upload_a_proof_of_death') }}" method="post" enctype="multipart/form-data" novalidate>
+          {{ form.proof_of_death }}
+          <div class="tna-button-group">
+            {{ form.submit(params={'accent':'true', 'icon':'chevron-right', 'rightAlignIcon':'true'}) }}
+          </div>
+        </form>
+      </div>
+    </div>
+  </div>
+  </div>
+{% endblock %}

--- a/test/main/test_state_machine.py
+++ b/test/main/test_state_machine.py
@@ -220,5 +220,31 @@ def test_continue_from_what_was_their_date_of_birth_form(
     assert sm.route_for_current_state == expected_route
 
 
+@pytest.mark.parametrize(
+    "has_proof_of_death,expected_state,expected_route",
+    [
+        (
+            "no",
+            "upload_a_proof_of_death_form",
+            MultiPageFormRoutes.UPLOAD_A_PROOF_OF_DEATH.value,
+        ),
+        (
+            "yes",
+            "upload_a_proof_of_death_form",
+            MultiPageFormRoutes.UPLOAD_A_PROOF_OF_DEATH.value,
+        ),
+    ],
+)
+def test_continue_from_upload_a_proof_of_death(
+    has_proof_of_death, expected_state, expected_route
+):
+    sm = RoutingStateMachine()
+    sm.continue_from_do_you_have_a_proof_of_death_form(
+        form=make_form("upload_a_proof_of_death", has_proof_of_death)
+    )
+    assert sm.current_state.id == expected_state
+    assert sm.route_for_current_state == expected_route
+
+
 def make_form(field_name: str, answer: str = None):
     return SimpleNamespace(**{field_name: SimpleNamespace(data=answer)})

--- a/test/playwright/multi-page-journey/do-you-have-a-proof-of-death.spec.ts
+++ b/test/playwright/multi-page-journey/do-you-have-a-proof-of-death.spec.ts
@@ -5,7 +5,8 @@ test.describe("The 'Do you have a proof of death?' form", () => {
 
   enum Urls {
     JOURNEY_START = `${basePath}/start/`,
-    DO_YOU_HAVE_A_PROOF_OF_DEATH = `${basePath}/do-you-have-a-proof-of-death`,
+    DO_YOU_HAVE_A_PROOF_OF_DEATH = `${basePath}/do-you-have-a-proof-of-death/`,
+    UPLOAD_A_PROOF_OF_DEATH = `${basePath}/upload-a-proof-of-death/`,
   }
 
   test.beforeEach(async ({ page }) => {
@@ -23,6 +24,32 @@ test.describe("The 'Do you have a proof of death?' form", () => {
       await expect(page.locator(".tna-form__error-message")).toHaveText(
         /Choosing an option is required/,
       );
+    });
+
+    const selectionMappings = [
+      {
+        label: "Yes",
+        url: Urls.UPLOAD_A_PROOF_OF_DEATH,
+        heading: /Upload a proof of death/,
+        description:
+          'when "Yes" is selected, the user is directed to "Upload a proof of death" form',
+      },
+      {
+        label: "No",
+        url: Urls.UPLOAD_A_PROOF_OF_DEATH,
+        heading: /Upload a proof of death/,
+        description:
+          'when "No" is selected, the user is directed to "Upload a proof of death" form',
+      },
+    ];
+
+    selectionMappings.forEach(({ label, url, heading, description }) => {
+      test(description, async ({ page }) => {
+        await page.getByLabel(label, { exact: true }).check();
+        await page.getByRole("button", { name: /Continue/i }).click();
+        await expect(page).toHaveURL(url);
+        await expect(page.locator("h1")).toHaveText(heading);
+      });
     });
   });
 });

--- a/test/playwright/multi-page-journey/upload-proof-of-death.spec.ts
+++ b/test/playwright/multi-page-journey/upload-proof-of-death.spec.ts
@@ -1,0 +1,68 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("The 'Upload proof of death' form", () => {
+  const basePath = "/request-a-service-record";
+
+  enum Urls {
+    JOURNEY_START = `${basePath}/start/`,
+    UPLOAD_A_PROOF_OF_DEATH = `${basePath}/upload-a-proof-of-death/`,
+  }
+
+  test.beforeEach(async ({ page }) => {
+    await page.goto(Urls.JOURNEY_START);
+    await page.goto(Urls.UPLOAD_A_PROOF_OF_DEATH);
+  });
+
+  test("has the correct heading", async ({ page }) => {
+    await expect(page.locator("h1")).toHaveText(/Upload a proof of death/);
+  });
+
+  test("the form should have the enctype='multipart/form-data'", async ({
+    page,
+  }) => {
+    // We need this for file uploads to work. Adding a specific test because it's easy to miss.
+    await expect(page.locator("form")).toHaveAttribute(
+      "enctype",
+      "multipart/form-data",
+    );
+  });
+
+  test.describe("when submitted", () => {
+    test("without a an uploaded file, shows an error", async ({ page }) => {
+      await page.getByRole("button", { name: /Continue/i }).click();
+      await expect(page.locator(".tna-form__error-message")).toHaveText(
+        /Uploading a file is required/,
+      );
+    });
+
+    test("with an uploaded file with the incorrect extension, shows an error", async ({
+      page,
+    }) => {
+      await page.getByLabel("Upload a file").setInputFiles({
+        name: "file.txt",
+        mimeType: "text/plain",
+        buffer: Buffer.from("this is a test file"),
+      });
+      await page.getByRole("button", { name: /Continue/i }).click();
+      await expect(page.locator(".tna-form__error-message")).toHaveText(
+        /Files must be in JPG, PNG or PDF format/,
+      );
+    });
+
+    ["jpg", "png", "pdf"].forEach((extension) => {
+      test(`with a valid filetype (of .${extension}) which is above the size limit, shows an error`, async ({
+        page,
+      }) => {
+        await page.getByLabel("Upload a file").setInputFiles({
+          name: `image.${extension}`,
+          mimeType: "text/plain",
+          buffer: Buffer.alloc(6 * 1024 * 1024),
+        });
+        await page.getByRole("button", { name: /Continue/i }).click();
+        await expect(page.locator(".tna-form__error-message")).toHaveText(
+          /The maximum file size is 5MB/,
+        );
+      });
+    });
+  });
+});


### PR DESCRIPTION
This pull request introduces a new "Upload a proof of death" step to the multi-page form journey, including new backend logic, form validation, templates, and tests. It also refactors the previous "Do you have a proof of death?" step to streamline naming and routing, and ensures the new upload step is integrated into the state machine and user journey.

## Major additions and changes

### Feature: "Upload a proof of death" step
- Added a new `UploadAProofOfDeath` form (`app/main/forms/upload_a_proof_of_death.py`) with file upload validation (JPG, PNG, PDF, max 5MB), and corresponding content and error messages in `content.yaml`.
- Added the `/upload-a-proof-of-death/` route and template, rendering the new form and handling validation and redirection.

### State machine and routing updates
- Extended the state machine to include the new `upload_a_proof_of_death_form` state and transition from "Do you have a proof of death?" to the upload step
- Updated `MultiPageFormRoutes` to add the new route value and rename the existing proof of death route for consistency.

### Content and template refactoring
- Refactored content and templates to use the new route and naming convention (`do_you_have_a_proof_of_death` instead of `do_you_have_a_proof_of_death_form`), and to display the correct headings and messages

## Testing
- Added comprehensive Playwright tests for the new upload step, including file type and size validation, and updated existing tests to use the new route and flow
- Extended Python state machine tests to cover the new upload step and transitions

These changes collectively add a robust, validated file upload step to the multi-page form journey and ensure the new flow is thoroughly tested and integrated.