### PR TITLE
FOI-78: Add breadcrumbs to all pages (and small fixes)

### DIFF
--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -5,9 +5,9 @@
 {%- from 'components/header/macro.html' import tnaHeader -%}
 {%- from 'components/error-summary/macro.html' import tnaErrorSummary -%}
 {%- from 'components/details/macro.html' import tnaDetails -%}
-{%- from 'components/breadcrumbs/macro.html' import tnaBreadcrumbs -%}
 
 {%- from 'macros/back-link.html' import backLink %}
+{%- from 'macros/mod-foi-breadcrumbs.html' import modFoiBreadcrumbs  %}
 
 {%- set theme = request.cookies.get('theme') or 'system' -%}
 {%- set themeAccent = themeAccent if themeAccent else 'green' -%}

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -7,7 +7,7 @@
 {%- from 'components/details/macro.html' import tnaDetails -%}
 {%- from 'components/breadcrumbs/macro.html' import tnaBreadcrumbs -%}
 
-{%- from 'macros/back-link.html' import back_link %}
+{%- from 'macros/back-link.html' import backLink %}
 
 {%- set theme = request.cookies.get('theme') or 'system' -%}
 {%- set themeAccent = themeAccent if themeAccent else 'green' -%}

--- a/app/templates/macros/back-link.html
+++ b/app/templates/macros/back-link.html
@@ -1,4 +1,4 @@
-{% macro back_link(url) -%}
+{% macro backLink(url) -%}
   <a href="{{ url }}" class="tna-button tna-button--plain">
     <i class="fa-solid fa-arrow-left" aria-hidden="true"></i>
     Back

--- a/app/templates/macros/mod-foi-breadcrumbs.html
+++ b/app/templates/macros/mod-foi-breadcrumbs.html
@@ -1,0 +1,14 @@
+{%- from 'components/breadcrumbs/macro.html' import tnaBreadcrumbs -%}
+
+{% macro modFoiBreadcrumbs(args) -%}
+<div class="tna-section tna-!--padding-top-xs tna-!--padding-bottom-s{% if args.hasAccentBackground %} tna-background-accent-light{% endif %}">
+  <div class="tna-container">
+    <div
+      class="tna-column tna-column--width-2-3 tna-column--width-5-6-medium tna-column--full-small tna-column--full-tiny">
+      {{ tnaBreadcrumbs({
+        'items': args.breadcrumbItems
+      }) }}
+    </div>
+  </div>
+</div>
+{%- endmacro %}

--- a/app/templates/main/multi-page-journey/do-you-have-a-proof-of-death.html
+++ b/app/templates/main/multi-page-journey/do-you-have-a-proof-of-death.html
@@ -29,7 +29,7 @@
           {{ form.csrf_token }}
           {{ form.do_you_have_a_proof_of_death(params={'headingLevel':2, 'headingSize':'l'}) }}
           <div class="tna-button-group">
-            {{ back_link(url_for('main.what_was_their_date_of_birth')) }}
+            {{ backLink(url_for('main.what_was_their_date_of_birth')) }}
             {{ form.submit(params={'accent':'true', 'icon': 'chevron-right', 'rightAlignIcon': 'true'}) }}
           </div>
         </form>

--- a/app/templates/main/multi-page-journey/do-you-have-a-proof-of-death.html
+++ b/app/templates/main/multi-page-journey/do-you-have-a-proof-of-death.html
@@ -3,6 +3,7 @@
 {%- set pageTitle = content.app.title -%}
 
 {% block content %}
+  {{ modFoiBreadcrumbs({'breadcrumbItems': breadcrumbItems}) }}
   <div class="tna-section">
     <div class="tna-container">
       <div

--- a/app/templates/main/multi-page-journey/have-you-checked-the-catalogue.html
+++ b/app/templates/main/multi-page-journey/have-you-checked-the-catalogue.html
@@ -15,7 +15,7 @@
           {{ form.csrf_token }}
           {{ form.have_you_checked_the_catalogue() }}
           <div class="tna-button-group">
-            {{ back_link(url_for('main.service_branch_form')) }}
+            {{ backLink(url_for('main.service_branch_form')) }}
             {{ form.submit(params={'accent':'true'}) }}
           </div>
         </form>

--- a/app/templates/main/multi-page-journey/have-you-checked-the-catalogue.html
+++ b/app/templates/main/multi-page-journey/have-you-checked-the-catalogue.html
@@ -3,6 +3,7 @@
 {%- set pageTitle = content.app.title -%}
 
 {% block content %}
+  {{ modFoiBreadcrumbs({'breadcrumbItems': breadcrumbItems}) }}
   <div class="tna-section">
     <div class="tna-container">
       <div
@@ -15,7 +16,7 @@
           {{ form.csrf_token }}
           {{ form.have_you_checked_the_catalogue() }}
           <div class="tna-button-group">
-            {{ backLink(url_for('main.service_branch_form')) }}
+            {{ backLink(url_for('main.start')) }}
             {{ form.submit(params={'accent':'true'}) }}
           </div>
         </form>

--- a/app/templates/main/multi-page-journey/is-service-person-alive.html
+++ b/app/templates/main/multi-page-journey/is-service-person-alive.html
@@ -12,7 +12,7 @@
           {{ form.csrf_token }}
           {{ form.is_service_person_alive(params={'headingLevel':1, 'headingSize':'xl'}) }}
           <div class="tna-button-group">
-            {{ back_link(url_for('main.have_you_checked_the_catalogue')) }}
+            {{ backLink(url_for('main.have_you_checked_the_catalogue')) }}
             {{ form.submit(params={'accent':'true'}) }}
           </div>
         </form>

--- a/app/templates/main/multi-page-journey/is-service-person-alive.html
+++ b/app/templates/main/multi-page-journey/is-service-person-alive.html
@@ -3,6 +3,7 @@
 {%- set pageTitle = content.app.title -%}
 
 {% block content %}
+  {{ modFoiBreadcrumbs({'breadcrumbItems': breadcrumbItems}) }}
   <div class="tna-section">
     <div class="tna-container">
       <div

--- a/app/templates/main/multi-page-journey/must-submit-subject-access-request.html
+++ b/app/templates/main/multi-page-journey/must-submit-subject-access-request.html
@@ -12,7 +12,7 @@
           <p>{{ paragraph }}</p>
         {% endfor %}
         <div class="tna-button-group">
-          {{ back_link(url_for('main.is_service_person_alive')) }}
+          {{ backLink(url_for('main.is_service_person_alive')) }}
         </div>
       </div>
     </div>

--- a/app/templates/main/multi-page-journey/must-submit-subject-access-request.html
+++ b/app/templates/main/multi-page-journey/must-submit-subject-access-request.html
@@ -3,6 +3,7 @@
 {%- set pageTitle = content.app.title -%}
 
 {% block content %}
+  {{ modFoiBreadcrumbs({'breadcrumbItems': breadcrumbItems}) }}
   <div class="tna-section">
     <div class="tna-container">
       <div

--- a/app/templates/main/multi-page-journey/search-the-catalogue.html
+++ b/app/templates/main/multi-page-journey/search-the-catalogue.html
@@ -17,7 +17,7 @@
           {% endfor %}
         </ul>
         <div class="tna-button-group">
-          {{ back_link(url_for('main.have_you_checked_the_catalogue')) }}
+          {{ backLink(url_for('main.have_you_checked_the_catalogue')) }}
           <a href="https://discovery.nationalarchives.gov.uk/" class="tna-button tna-button--accent">
             <i class="fa-solid fa-arrow-right" aria-hidden="true"></i>
             {{ content.pages.search_the_catalogue.call_to_action }}

--- a/app/templates/main/multi-page-journey/search-the-catalogue.html
+++ b/app/templates/main/multi-page-journey/search-the-catalogue.html
@@ -3,6 +3,7 @@
 {%- set pageTitle = content.app.title -%}
 
 {% block content %}
+  {{ modFoiBreadcrumbs({'breadcrumbItems': breadcrumbItems}) }}
   <div class="tna-section">
     <div class="tna-container">
       <div

--- a/app/templates/main/multi-page-journey/service-branch.html
+++ b/app/templates/main/multi-page-journey/service-branch.html
@@ -12,7 +12,7 @@
           {{ form.service_branch(params={'headingLevel':1, 'headingSize':'xl'}) }}
           {{ form.csrf_token }}
           <div class="tna-button-group">
-            {{ back_link(url_for('main.is_service_person_alive')) }}
+            {{ backLink(url_for('main.is_service_person_alive')) }}
             {{ form.submit(params={'accent':'true'}) }}
           </div>
         </form>

--- a/app/templates/main/multi-page-journey/service-branch.html
+++ b/app/templates/main/multi-page-journey/service-branch.html
@@ -3,6 +3,7 @@
 {%- set pageTitle = content.app.title -%}
 
 {% block content %}
+  {{ modFoiBreadcrumbs({'breadcrumbItems': breadcrumbItems}) }}
   <div class="tna-section">
     <div class="tna-container">
       <div

--- a/app/templates/main/multi-page-journey/service-person-details.html
+++ b/app/templates/main/multi-page-journey/service-person-details.html
@@ -3,6 +3,7 @@
 {%- set pageTitle = content.app.title -%}
 
 {% block content %}
+  {{ modFoiBreadcrumbs({'breadcrumbItems': breadcrumbItems}) }}
   <div class="tna-section">
     <div class="tna-container">
       <div

--- a/app/templates/main/multi-page-journey/start.html
+++ b/app/templates/main/multi-page-journey/start.html
@@ -3,16 +3,7 @@
 {%- set pageTitle = content.app.title -%}
 
 {% block content %}
-<div class="tna-section tna-!--padding-top-xs tna-!--padding-bottom-s tna-background-accent-light">
-  <div class="tna-container">
-    <div
-      class="tna-column tna-column--width-2-3 tna-column--width-5-6-medium tna-column--full-small tna-column--full-tiny">
-      {{ tnaBreadcrumbs({
-        'items': breadcrumbItems
-      }) }}
-    </div>
-  </div>
-</div>
+{{ modFoiBreadcrumbs({'breadcrumbItems': breadcrumbItems, 'hasAccentBackground': true}) }}
 <div class="tna-section tna-background-accent-light">
   <div class="tna-container">
     <div

--- a/app/templates/main/multi-page-journey/upload-a-proof-of-death.html
+++ b/app/templates/main/multi-page-journey/upload-a-proof-of-death.html
@@ -3,6 +3,7 @@
 {%- set pageTitle = content.app.title -%}
 
 {% block content %}
+  {{ modFoiBreadcrumbs({'breadcrumbItems': breadcrumbItems}) }}
   <div class="tna-section">
     <div class="tna-container">
       <div

--- a/app/templates/main/multi-page-journey/was-service-person-an-officer.html
+++ b/app/templates/main/multi-page-journey/was-service-person-an-officer.html
@@ -11,7 +11,7 @@
           {{ form.csrf_token }}
           {{ form.was_service_person_an_officer(params={'headingLevel':1, 'headingSize':'xl'}) }}
           <div class="tna-button-group">
-            {{ back_link(url_for('main.service_branch_form')) }}
+            {{ backLink(url_for('main.service_branch_form')) }}
             {{ form.submit(params={'accent':'true'}) }}
           </div>
         </form>

--- a/app/templates/main/multi-page-journey/was-service-person-an-officer.html
+++ b/app/templates/main/multi-page-journey/was-service-person-an-officer.html
@@ -3,6 +3,7 @@
 {%- set pageTitle = content.app.title -%}
 
 {% block content %}
+  {{ modFoiBreadcrumbs({'breadcrumbItems': breadcrumbItems}) }}
   <div class="tna-section">
     <div class="tna-container">
       <div

--- a/app/templates/main/multi-page-journey/we-do-not-have-records-for-people-born-after.html
+++ b/app/templates/main/multi-page-journey/we-do-not-have-records-for-people-born-after.html
@@ -3,6 +3,7 @@
 {%- set pageTitle = content.app.title -%}
 
 {% block content %}
+  {{ modFoiBreadcrumbs({'breadcrumbItems': breadcrumbItems}) }}
   <div class="tna-section">
     <div class="tna-container">
       <div

--- a/app/templates/main/multi-page-journey/we-do-not-have-records-for-people-born-before.html
+++ b/app/templates/main/multi-page-journey/we-do-not-have-records-for-people-born-before.html
@@ -3,6 +3,7 @@
 {%- set pageTitle = content.app.title -%}
 
 {% block content %}
+  {{ modFoiBreadcrumbs({'breadcrumbItems': breadcrumbItems}) }}
   <div class="tna-section">
     <div class="tna-container">
       <div

--- a/app/templates/main/multi-page-journey/we-do-not-have-records-for-this-rank.html
+++ b/app/templates/main/multi-page-journey/we-do-not-have-records-for-this-rank.html
@@ -3,6 +3,7 @@
 {%- set pageTitle = content.app.title -%}
 
 {% block content %}
+  {{ modFoiBreadcrumbs({'breadcrumbItems': breadcrumbItems}) }}
   <div class="tna-section">
     <div class="tna-container">
       <div

--- a/app/templates/main/multi-page-journey/we-do-not-have-records-for-this-service-branch.html
+++ b/app/templates/main/multi-page-journey/we-do-not-have-records-for-this-service-branch.html
@@ -3,6 +3,7 @@
 {%- set pageTitle = content.app.title -%}
 
 {% block content %}
+  {{ modFoiBreadcrumbs({'breadcrumbItems': breadcrumbItems}) }}
   <div class="tna-section">
     <div class="tna-container">
       <div

--- a/app/templates/main/multi-page-journey/we-may-be-unable-to-find-this-record.html
+++ b/app/templates/main/multi-page-journey/we-may-be-unable-to-find-this-record.html
@@ -3,6 +3,7 @@
 {%- set pageTitle = content.app.title -%}
 
 {% block content %}
+  {{ modFoiBreadcrumbs({'breadcrumbItems': breadcrumbItems}) }}
   <div class="tna-section">
     <div class="tna-container">
       <div

--- a/app/templates/main/multi-page-journey/we-may-hold-this-record.html
+++ b/app/templates/main/multi-page-journey/we-may-hold-this-record.html
@@ -26,7 +26,7 @@
         <form action="{{ url_for('main.we_may_hold_this_record') }}" method="post" novalidate>
           {{ form.csrf_token }}
           <div class="tna-button-group">
-            {{ back_link(url_for('main.was_service_person_an_officer')) }}
+            {{ backLink(url_for('main.was_service_person_an_officer')) }}
             {{ form.submit(params={'accent':'true'}) }}
           </div>
         </form>

--- a/app/templates/main/multi-page-journey/we-may-hold-this-record.html
+++ b/app/templates/main/multi-page-journey/we-may-hold-this-record.html
@@ -3,6 +3,7 @@
 {%- set pageTitle = content.app.title -%}
 
 {% block content %}
+  {{ modFoiBreadcrumbs({'breadcrumbItems': breadcrumbItems}) }}
   <div class="tna-section">
     <div class="tna-container">
       <div

--- a/app/templates/main/multi-page-journey/what-was-their-date-of-birth.html
+++ b/app/templates/main/multi-page-journey/what-was-their-date-of-birth.html
@@ -11,7 +11,7 @@
           {{ form.csrf_token }}
           {{ form.what_was_their_date_of_birth(params={'headingLevel':1, 'headingSize':'xl'}) }}
           <div class="tna-button-group">
-            {{ backLink(url_for('main.was_service_person_an_officer')) }}
+            {{ backLink(url_for('main.we_may_hold_this_record')) }}
             {{ form.submit(params={'accent':'true'}) }}
           </div>
         </form>

--- a/app/templates/main/multi-page-journey/what-was-their-date-of-birth.html
+++ b/app/templates/main/multi-page-journey/what-was-their-date-of-birth.html
@@ -11,7 +11,7 @@
           {{ form.csrf_token }}
           {{ form.what_was_their_date_of_birth(params={'headingLevel':1, 'headingSize':'xl'}) }}
           <div class="tna-button-group">
-            {{ back_link(url_for('main.was_service_person_an_officer')) }}
+            {{ backLink(url_for('main.was_service_person_an_officer')) }}
             {{ form.submit(params={'accent':'true'}) }}
           </div>
         </form>

--- a/app/templates/main/multi-page-journey/what-was-their-date-of-birth.html
+++ b/app/templates/main/multi-page-journey/what-was-their-date-of-birth.html
@@ -3,6 +3,7 @@
 {%- set pageTitle = content.app.title -%}
 
 {% block content %}
+  {{ modFoiBreadcrumbs({'breadcrumbItems': breadcrumbItems}) }}
   <div class="tna-section">
     <div class="tna-container">
       <div

--- a/test/playwright/multi-page-journey/start-page.spec.ts
+++ b/test/playwright/multi-page-journey/start-page.spec.ts
@@ -1,12 +1,13 @@
 import { test, expect } from "@playwright/test";
 
 test.describe("application start page", () => {
-  const JOURNEY_START_PAGE_URL = "/request-a-service-record/start/";
-  const HAVE_YOU_CHECKED_THE_CATALOGUE =
-    "/request-a-service-record/have-you-checked-the-catalogue/";
+  enum Urls {
+    START_PAGE = "/request-a-service-record/start/",
+    HAVE_YOU_CHECKED_THE_CATALOGUE = "/request-a-service-record/have-you-checked-the-catalogue/",
+  }
 
   test.beforeEach(async ({ page }) => {
-    await page.goto(JOURNEY_START_PAGE_URL);
+    await page.goto(Urls.START_PAGE);
   });
 
   test("has the correct heading", async ({ page }) => {
@@ -19,9 +20,18 @@ test.describe("application start page", () => {
     page,
   }) => {
     await page.getByRole("button", { name: /Start now/i }).click();
-    await expect(page).toHaveURL(HAVE_YOU_CHECKED_THE_CATALOGUE);
+    await expect(page).toHaveURL(Urls.HAVE_YOU_CHECKED_THE_CATALOGUE);
     await expect(page.locator("h1")).toHaveText(
       /Have you checked if this record is available in our catalogue\?/,
     );
+  });
+
+  test("clicking 'Back' from 'Have you checked the catalogue?' brings the user back to the start page", async ({
+    page,
+  }) => {
+    await page.getByRole("button", { name: /Start now/i }).click();
+    await expect(page).toHaveURL(Urls.HAVE_YOU_CHECKED_THE_CATALOGUE);
+    await page.getByRole("link", { name: "Back" }).click();
+    await expect(page).toHaveURL(Urls.START_PAGE);
   });
 });

--- a/test/playwright/multi-page-journey/we-may-hold-this-record.spec.ts
+++ b/test/playwright/multi-page-journey/we-may-hold-this-record.spec.ts
@@ -29,13 +29,13 @@ test.describe("the 'We may hold this record' form", () => {
       );
     });
 
-  test("clicking 'Back' from 'What was their date of birth?' brings the user back to the 'We may hold this record' page", async ({
-    page,
-  }) => {
-    await page.getByRole("button", { name: /Continue/i }).click();
-    await expect(page).toHaveURL(Urls.WHAT_WAS_THEIR_DATE_OF_BIRTH);
-    await page.getByRole("link", { name: "Back" }).click();
-    await expect(page).toHaveURL(Urls.WE_MAY_HOLD_THIS_RECORD);
-  });
+    test("clicking 'Back' from 'What was their date of birth?' brings the user back to the 'We may hold this record' page", async ({
+      page,
+    }) => {
+      await page.getByRole("button", { name: /Continue/i }).click();
+      await expect(page).toHaveURL(Urls.WHAT_WAS_THEIR_DATE_OF_BIRTH);
+      await page.getByRole("link", { name: "Back" }).click();
+      await expect(page).toHaveURL(Urls.WE_MAY_HOLD_THIS_RECORD);
+    });
   });
 });

--- a/test/playwright/multi-page-journey/we-may-hold-this-record.spec.ts
+++ b/test/playwright/multi-page-journey/we-may-hold-this-record.spec.ts
@@ -28,5 +28,14 @@ test.describe("the 'We may hold this record' form", () => {
         /What was their date of birth?/,
       );
     });
+
+  test("clicking 'Back' from 'What was their date of birth?' brings the user back to the 'We may hold this record' page", async ({
+    page,
+  }) => {
+    await page.getByRole("button", { name: /Continue/i }).click();
+    await expect(page).toHaveURL(Urls.WHAT_WAS_THEIR_DATE_OF_BIRTH);
+    await page.getByRole("link", { name: "Back" }).click();
+    await expect(page).toHaveURL(Urls.WE_MAY_HOLD_THIS_RECORD);
+  });
   });
 });


### PR DESCRIPTION
This pull request refactors the way breadcrumbs and back links are handled across the multi-page journey templates. The main improvements are the introduction of a new macro for consistent breadcrumb rendering, the renaming of the back link macro for naming consistency, and the update of all relevant templates to use these new macros. This results in a more maintainable and uniform user interface.

## Breadcrumbs and Navigation Consistency:

* Introduced a new macro `modFoiBreadcrumbs` in `mod-foi-breadcrumbs.html` for rendering breadcrumbs, which wraps the existing `tnaBreadcrumbs` macro and adds optional accent background support. All journey templates now use this macro for consistent breadcrumb display.
* Updated all multi-page journey templates (e.g., `start.html`, `do-you-have-a-proof-of-death.html`, `have-you-checked-the-catalogue.html`, etc.) to use the new `modFoiBreadcrumbs` macro, ensuring breadcrumbs are consistently displayed at the top of each page.

## Macro Naming Consistency and Usage:

* Renamed the back link macro from `back_link` to `backLink` in `back-link.html` and updated all references in templates to use the new name, aligning with naming conventions and improving code readability. [[1]](diffhunk://#diff-71eeaeb0c6bc037519b39997408b5c8cf36f66f5d9f9297a84b27daee0d158ebL1-R1) [[2]](diffhunk://#diff-9ba5b84a377a6a734932f7f6a3003e6f8bae1b02c34cf4729cfc95a5fd6179c8L8-R10)
* Replaced all instances of the old `back_link` macro in journey templates with the new `backLink` macro, and adjusted the target URLs where needed for navigation improvements.

These changes collectively improve maintainability, consistency, and user experience across the application's multi-page journey.