### PR TITLE
FOI-74: Create "About the service person" form

### DIFF
--- a/app/constants.py
+++ b/app/constants.py
@@ -27,6 +27,7 @@ class MultiPageFormRoutes(Enum):
     SERVICE_PERSON_DETAILS = "main.service_person_details"
     DO_YOU_HAVE_A_PROOF_OF_DEATH = "main.do_you_have_a_proof_of_death"
     UPLOAD_A_PROOF_OF_DEATH = "main.upload_a_proof_of_death"
+    HAVE_YOU_PREVIOUSLY_MADE_A_REQUEST = "main.have_you_previously_made_a_request"
 
 
 class ServiceBranches(Enum):

--- a/app/content/content.yaml
+++ b/app/content/content.yaml
@@ -123,9 +123,7 @@ pages:
       - no more than 5MB
       - clear and show all the death certificate
   service_person_details:
-    heading: Service person details
-    paragraphs:
-      - Service person details content to go here
+    heading: About the service person
   do_you_have_a_proof_of_death:
     heading: Provide a proof of death
     paragraphs:
@@ -206,6 +204,12 @@ forms:
       label: Forenames (including middle names)
       messages:
         required: The service person's first name is required
+    first_name:
+      label: First name
+      messages:
+        required: The service person's first name is required
+    middle_names:
+      label: Middle names (optional)
     last_name:
       label: Last name
       messages:
@@ -260,7 +264,7 @@ forms:
         file_allowed: File type not allowed. Only .jpg, .png, .gif files are accepted.
         file_size: File size must be less than 20MB.
     died_in_service:
-      label: Do you believe the individual may have died in service?
+      label: Did they die in service? (optional)
       messages:
         required: Choosing an option for death in service is required
     case_reference_number:

--- a/app/content/content.yaml
+++ b/app/content/content.yaml
@@ -50,6 +50,8 @@ pages:
   have_you_checked_the_catalogue:
     heading: Have you checked if this record is available in our catalogue?
     paragraph: A portion of the service records we hold are listed in our catalogue and are available to order from there.
+  have_you_previously_made_a_request:
+    heading: Have you previously made a request?
   search_the_catalogue:
     heading: Search our catalogue
     paragraphs:

--- a/app/lib/state_machine/state_machine.py
+++ b/app/lib/state_machine/state_machine.py
@@ -134,6 +134,8 @@ class RoutingStateMachine(StateMachine):
         upload_a_proof_of_death_form
     )
 
+    continue_from_upload_a_proof_of_death_form = initial.to(service_person_details_form)
+
     def entering_have_you_checked_the_catalogue_form(self, event, state):
         self.route_for_current_state = (
             MultiPageFormRoutes.HAVE_YOU_CHECKED_THE_CATALOGUE.value

--- a/app/lib/state_machine/state_machine.py
+++ b/app/lib/state_machine/state_machine.py
@@ -77,6 +77,9 @@ class RoutingStateMachine(StateMachine):
     upload_a_proof_of_death_form = State(
         enter="entering_upload_a_proof_of_death_form", final=True
     )
+    have_you_previously_made_a_request_form = State(
+        enter="entering_have_you_previously_made_a_request_form", final=True
+    )
 
     """
     These are our Events. They're called in route methods to trigger transitions between States.
@@ -135,6 +138,10 @@ class RoutingStateMachine(StateMachine):
     )
 
     continue_from_upload_a_proof_of_death_form = initial.to(service_person_details_form)
+
+    continue_from_service_person_details_form = initial.to(
+        have_you_previously_made_a_request_form
+    )
 
     def entering_have_you_checked_the_catalogue_form(self, event, state):
         self.route_for_current_state = (
@@ -208,6 +215,11 @@ class RoutingStateMachine(StateMachine):
 
     def entering_upload_a_proof_of_death_form(self, form):
         self.route_for_current_state = MultiPageFormRoutes.UPLOAD_A_PROOF_OF_DEATH.value
+
+    def entering_have_you_previously_made_a_request_form(self, form):
+        self.route_for_current_state = (
+            MultiPageFormRoutes.HAVE_YOU_PREVIOUSLY_MADE_A_REQUEST.value
+        )
 
     def on_enter_state(self, event, state):
         """This method is called when entering any state."""

--- a/app/main/forms/service_person_details.py
+++ b/app/main/forms/service_person_details.py
@@ -1,0 +1,95 @@
+from app.lib.content import get_field_content, load_content
+from flask_wtf import FlaskForm
+from tna_frontend_jinja.wtforms import (
+    TnaDateField,
+    TnaRadiosWidget,
+    TnaSubmitWidget,
+    TnaTextareaWidget,
+    TnaTextInputWidget,
+)
+from tna_frontend_jinja.wtforms import validators as tna_frontend_validators
+from wtforms import (
+    RadioField,
+    StringField,
+    SubmitField,
+    TextAreaField,
+)
+from wtforms.validators import InputRequired
+
+
+class ServicePersonDetails(FlaskForm):
+    content = load_content()
+
+    first_name = StringField(
+        get_field_content(content, "first_name", "label"),
+        widget=TnaTextInputWidget(),
+        validators=[
+            InputRequired(
+                message=get_field_content(content, "first_name", "messages")["required"]
+            ),
+        ],
+    )
+
+    middle_names = StringField(
+        get_field_content(content, "middle_names", "label"),
+        widget=TnaTextInputWidget(),
+        validators=[],
+    )
+
+    last_name = StringField(
+        get_field_content(content, "last_name", "label"),
+        widget=TnaTextInputWidget(),
+        validators=[
+            InputRequired(
+                message=get_field_content(content, "last_name", "messages")["required"]
+            )
+        ],
+    )
+
+    place_of_birth = StringField(
+        get_field_content(content, "place_of_birth", "label"),
+        widget=TnaTextInputWidget(),
+        validators=[],
+    )
+
+    date_of_death = TnaDateField(
+        get_field_content(content, "date_of_death", "label"),
+        description=get_field_content(content, "date_of_death", "description"),
+        validators=[
+            tna_frontend_validators.PastDate(
+                message=get_field_content(content, "date_of_death", "messages")[
+                    "past_date"
+                ],
+                include_today=True,
+            ),
+        ],
+    )
+
+    died_in_service = RadioField(
+        get_field_content(content, "died_in_service", "label"),
+        choices=[("yes", "Yes"), ("no", "No"), ("dont_know", "Don't know")],
+        validators=[],
+        widget=TnaRadiosWidget(),
+        validate_choice=False,
+    )
+
+    service_number = StringField(
+        get_field_content(content, "service_number", "label"),
+        widget=TnaTextInputWidget(),
+        validators=[],
+    )
+
+    regiment = StringField(
+        get_field_content(content, "regiment", "label"),
+        widget=TnaTextInputWidget(),
+        validators=[],
+    )
+
+    additional_information = TextAreaField(
+        get_field_content(content, "additional_information", "label"),
+        description=get_field_content(content, "additional_information", "description"),
+        validators=[],
+        widget=TnaTextareaWidget(),
+    )
+
+    submit = SubmitField("Continue", widget=TnaSubmitWidget())

--- a/app/main/routes/routes_multiple_forms_journey.py
+++ b/app/main/routes/routes_multiple_forms_journey.py
@@ -214,7 +214,20 @@ def do_you_have_a_proof_of_death(form, state_machine):
 @with_state_machine
 def upload_a_proof_of_death(form, state_machine):
     if form.validate_on_submit():
-        return redirect(url_for("main.service_person_details"))
+        # Note: We should probably call the API from the state machine (as part of the continue_from_* method)
+        #       so that it is the state machine that decides what state the user should be in
+        #       next (this is easy to extend too because we can have the state machine do different
+        #       things based on different conditions - one state for the API being down, another for
+        #       the upload being successful but virus scanning identifying a problem, etc.)
+
+        #       My sense is that this will probably be best achieved a dedicated page initially, but
+        #       it's for UCD to decide how best to handle this from a user experience perspective.
+        #       The key point is that this is probably not best treated as validation error on the form
+        #       because:
+        #         1. it's not necessarily a problem with the data the user has provided
+        #         2. it will likely require us to communicate next steps to the user
+        state_machine.continue_from_upload_a_proof_of_death_form(form)
+        return redirect(url_for(state_machine.route_for_current_state))
     return render_template(
         "main/multi-page-journey/upload-a-proof-of-death.html",
         form=form,

--- a/app/main/routes/routes_multiple_forms_journey.py
+++ b/app/main/routes/routes_multiple_forms_journey.py
@@ -13,6 +13,7 @@ from app.main.forms.was_service_person_an_officer import WasServicePersonAnOffic
 from app.main.forms.we_may_hold_this_record import WeMayHoldThisRecord
 from app.main.forms.what_was_their_date_of_birth import WhatWasTheirDateOfBirth
 from app.main.forms.upload_a_proof_of_death import UploadAProofOfDeath
+from app.main.forms.service_person_details import ServicePersonDetails
 from flask import redirect, render_template, session, url_for
 
 
@@ -187,10 +188,19 @@ def we_do_not_have_records_for_people_born_after():
     )
 
 
-@bp.route("/service-person-details/", methods=["GET"])
-def service_person_details():
+@bp.route("/service-person-details/", methods=["GET", "POST"])
+@with_form_prefilled_from_session(ServicePersonDetails)
+@with_state_machine
+def service_person_details(form, state_machine):
+    if form.validate_on_submit():
+        session["form_data"] = {}
+        for field_name, field in form._fields.items():
+            if field_name not in ["csrf_token", "submit"]:
+                session["form_data"][field_name] = field.data
     return render_template(
-        "main/multi-page-journey/service-person-details.html", content=load_content()
+        "main/multi-page-journey/service-person-details.html",
+        form=form,
+        content=load_content(),
     )
 
 

--- a/app/main/routes/routes_multiple_forms_journey.py
+++ b/app/main/routes/routes_multiple_forms_journey.py
@@ -197,9 +197,19 @@ def service_person_details(form, state_machine):
         for field_name, field in form._fields.items():
             if field_name not in ["csrf_token", "submit"]:
                 session["form_data"][field_name] = field.data
+        state_machine.continue_from_service_person_details_form(form)
+        return redirect(url_for(state_machine.route_for_current_state))
     return render_template(
         "main/multi-page-journey/service-person-details.html",
         form=form,
+        content=load_content(),
+    )
+
+
+@bp.route("/have-you-previously-made-a-request/", methods=["GET"])
+def have_you_previously_made_a_request():
+    return render_template(
+        "main/multi-page-journey/have-you-previously-made-a-request.html",
         content=load_content(),
     )
 

--- a/app/templates/main/multi-page-journey/have-you-previously-made-a-request.html
+++ b/app/templates/main/multi-page-journey/have-you-previously-made-a-request.html
@@ -1,0 +1,15 @@
+{% extends 'base.html' %}
+
+{%- set pageTitle = content.app.title -%}
+
+{% block content %}
+  {{ modFoiBreadcrumbs({'breadcrumbItems': breadcrumbItems}) }}
+  <div class="tna-section">
+    <div class="tna-container">
+      <div
+        class="tna-column tna-column--width-2-3 tna-column--width-5-6-medium tna-column--full-small tna-column--full-tiny">
+        <h1 class="tna-heading-xl">{{ content.pages.have_you_previously_made_a_request.heading }}</h1>
+      </div>
+    </div>
+  </div>
+{% endblock %}

--- a/app/templates/main/multi-page-journey/service-person-details.html
+++ b/app/templates/main/multi-page-journey/service-person-details.html
@@ -8,10 +8,26 @@
     <div class="tna-container">
       <div
         class="tna-column tna-column--width-2-3 tna-column--width-5-6-medium tna-column--full-small tna-column--full-tiny">
+        {% if form.errors %}
+          {{ tnaErrorSummary(wtforms_errors(form)) }}
+        {% endif %}
         <h1 class="tna-heading-xl">{{ content.pages.service_person_details.heading }}</h1>
-        {% for paragraph in content.pages.service_person_details.paragraphs %}
-          <p>{{ paragraph }}</p>
-        {% endfor %}
+        <form action="{{ url_for('main.service_person_details') }}" method="post" novalidate>
+          {{ form.csrf_token }}
+          {{ form.first_name(params={'headingLevel':2, 'size':'l', 'autocomplete':'off'}) }}
+          {{ form.middle_names(params={'headingLevel':2, 'size':'m', 'autocomplete':'off'}) }}
+          {{ form.last_name(params={'headingLevel':2, 'size':'m', 'autocomplete':'off'}) }}
+          {{ form.place_of_birth(params={'headingLevel':2, 'size':'m', 'autocomplete':'off'}) }}
+          {{ form.date_of_death(params={'headingLevel':2, 'autocomplete':'off'}) }}
+          {{ form.died_in_service(params={'headingLevel':2}) }}
+          {{ form.service_number(params={'headingLevel':2, 'size':'m', 'autocomplete':'off'}) }}
+          {{ form.regiment(params={'headingLevel':2, 'size':'m', 'autocomplete':'off'}) }}
+          {{ form.additional_information(params={'headingLevel':2}) }}
+          <div class="tna-button-group">
+            {{ backLink(url_for('main.what_was_their_date_of_birth')) }}
+            {{ form.submit(params={'accent':'true'}) }}
+          </div>
+        </form>
       </div>
     </div>
   </div>

--- a/app/templates/main/multi-page-journey/upload-a-proof-of-death.html
+++ b/app/templates/main/multi-page-journey/upload-a-proof-of-death.html
@@ -19,6 +19,7 @@
         </ul>
         <form action="{{ url_for('main.upload_a_proof_of_death') }}" method="post" enctype="multipart/form-data" novalidate>
           {{ form.proof_of_death }}
+          {{ form.csrf_token }}
           <div class="tna-button-group">
             {{ form.submit(params={'accent':'true', 'icon':'chevron-right', 'rightAlignIcon':'true'}) }}
           </div>

--- a/test/main/test_state_machine.py
+++ b/test/main/test_state_machine.py
@@ -255,5 +255,17 @@ def test_continue_from_upload_a_proof_of_death():
     assert sm.route_for_current_state == "main.service_person_details"
 
 
+def test_continue_from_service_person_details():
+    sm = RoutingStateMachine()
+    sm.continue_from_service_person_details_form(
+        form=make_form("service_person_details")
+    )
+    assert sm.current_state.id == "have_you_previously_made_a_request_form"
+    assert (
+        sm.route_for_current_state
+        == MultiPageFormRoutes.HAVE_YOU_PREVIOUSLY_MADE_A_REQUEST.value
+    )
+
+
 def make_form(field_name: str, answer: str = None):
     return SimpleNamespace(**{field_name: SimpleNamespace(data=answer)})

--- a/test/main/test_state_machine.py
+++ b/test/main/test_state_machine.py
@@ -235,7 +235,7 @@ def test_continue_from_what_was_their_date_of_birth_form(
         ),
     ],
 )
-def test_continue_from_upload_a_proof_of_death(
+def test_continue_from_do_you_have_a_proof_of_death(
     has_proof_of_death, expected_state, expected_route
 ):
     sm = RoutingStateMachine()
@@ -244,6 +244,15 @@ def test_continue_from_upload_a_proof_of_death(
     )
     assert sm.current_state.id == expected_state
     assert sm.route_for_current_state == expected_route
+
+
+def test_continue_from_upload_a_proof_of_death():
+    sm = RoutingStateMachine()
+    sm.continue_from_upload_a_proof_of_death_form(
+        form=make_form("upload_a_proof_of_death")
+    )
+    assert sm.current_state.id == "service_person_details_form"
+    assert sm.route_for_current_state == "main.service_person_details"
 
 
 def make_form(field_name: str, answer: str = None):

--- a/test/playwright/multi-page-journey/service-person-details.spec.ts
+++ b/test/playwright/multi-page-journey/service-person-details.spec.ts
@@ -6,6 +6,7 @@ test.describe("the 'About the service person form?' form", () => {
   enum Urls {
     JOURNEY_START_PAGE = `${basePath}/start/`,
     SERVICE_PERSON_DETAILS = `${basePath}/service-person-details/`,
+    HAVE_YOU_PREVIOUSLY_MADE_A_REQUEST = `${basePath}/have-you-previously-made-a-request/`,
   }
 
   test.beforeEach(async ({ page }) => {
@@ -38,6 +39,26 @@ test.describe("the 'About the service person form?' form", () => {
         await expect(
           page.locator(".tna-form__error-message").nth(1),
         ).toHaveText(/The service person's last name is required/);
+      });
+    });
+    test.describe("with valid input", () => {
+      test("with only the required fields filled in, the user is taken to the next page", async ({
+        page,
+      }) => {
+        await page.getByLabel("First name").fill("Thomas");
+        await page.getByLabel("Last name").fill("Duffus");
+        await page.getByRole("button", { name: /Continue/i }).click();
+        await expect(page).toHaveURL(Urls.HAVE_YOU_PREVIOUSLY_MADE_A_REQUEST);
+      });
+      test("with all fields filled in, the user is taken to the next page", async ({
+        page,
+      }) => {
+        await page.getByLabel("First name").fill("Thomas");
+        await page.getByLabel("Middle names").fill("Duffus");
+        await page.getByLabel("Last name").fill("Hardy");
+        await page.getByLabel("Service number").fill("123456");
+        await page.getByRole("button", { name: /Continue/i }).click();
+        await expect(page).toHaveURL(Urls.HAVE_YOU_PREVIOUSLY_MADE_A_REQUEST);
       });
     });
   });

--- a/test/playwright/multi-page-journey/service-person-details.spec.ts
+++ b/test/playwright/multi-page-journey/service-person-details.spec.ts
@@ -1,0 +1,44 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("the 'About the service person form?' form", () => {
+  const basePath = "/request-a-service-record";
+
+  enum Urls {
+    JOURNEY_START_PAGE = `${basePath}/start/`,
+    SERVICE_PERSON_DETAILS = `${basePath}/service-person-details/`,
+  }
+
+  test.beforeEach(async ({ page }) => {
+    await page.goto(Urls.JOURNEY_START_PAGE); // We need to go here first because we prevent direct access to mid-journey pages
+    await page.goto(Urls.SERVICE_PERSON_DETAILS);
+  });
+
+  test("has the correct heading", async ({ page }) => {
+    await expect(page.locator("h1")).toHaveText(/About the service person/);
+  });
+
+  test.describe("when submitted", () => {
+    test.describe("with invalid input", () => {
+      test("without any input, the validation summary is shown", async ({
+        page,
+      }) => {
+        await page.getByRole("button", { name: /Continue/i }).click();
+        await expect(page.locator(".tna-error-summary")).toHaveText(
+          /There is a problem/,
+        );
+      });
+      test("and errors are shown against only the required fields", async ({
+        page,
+      }) => {
+        await page.getByRole("button", { name: /Continue/i }).click();
+        await expect(page.locator(".tna-form__error-message")).toHaveCount(2);
+        await expect(
+          page.locator(".tna-form__error-message").first(),
+        ).toHaveText(/The service person's first name is required/);
+        await expect(
+          page.locator(".tna-form__error-message").nth(1),
+        ).toHaveText(/The service person's last name is required/);
+      });
+    });
+  });
+});

--- a/test/playwright/multi-page-journey/upload-proof-of-death.spec.ts
+++ b/test/playwright/multi-page-journey/upload-proof-of-death.spec.ts
@@ -6,6 +6,7 @@ test.describe("The 'Upload proof of death' form", () => {
   enum Urls {
     JOURNEY_START = `${basePath}/start/`,
     UPLOAD_A_PROOF_OF_DEATH = `${basePath}/upload-a-proof-of-death/`,
+    SERVICE_PERSON_DETAILS = `${basePath}/service-person-details/`,
   }
 
   test.beforeEach(async ({ page }) => {
@@ -50,7 +51,7 @@ test.describe("The 'Upload proof of death' form", () => {
     });
 
     ["jpg", "png", "pdf"].forEach((extension) => {
-      test(`with a valid filetype (of .${extension}) which is above the size limit, shows an error`, async ({
+      test(`with a valid extension (of .${extension}) which is above the size limit, shows an error`, async ({
         page,
       }) => {
         await page.getByLabel("Upload a file").setInputFiles({
@@ -62,6 +63,17 @@ test.describe("The 'Upload proof of death' form", () => {
         await expect(page.locator(".tna-form__error-message")).toHaveText(
           /The maximum file size is 5MB/,
         );
+      });
+      test(`with a file that has a valid extention (of .${extension}) and is below the size limit, presents next page`, async ({
+        page,
+      }) => {
+        await page.getByLabel("Upload a file").setInputFiles({
+          name: `image.${extension}`,
+          mimeType: "text/plain",
+          buffer: Buffer.alloc(2 * 1024 * 1024),
+        });
+        await page.getByRole("button", { name: /Continue/i }).click();
+        await expect(page).toHaveURL(Urls.SERVICE_PERSON_DETAILS);
       });
     });
   });

--- a/test/playwright/multi-page-journey/what-was-their-date-of-birth.spec.ts
+++ b/test/playwright/multi-page-journey/what-was-their-date-of-birth.spec.ts
@@ -78,9 +78,9 @@ test.describe("the 'What was their date of birth?' form", () => {
           day: "01",
           year: "1890",
           nextUrl: Urls.SERVICE_PERSON_DETAILS,
-          heading: /Service person details/,
+          heading: /About the service person/,
           description:
-            "when the year of birth is 1890, the 'Service person details' page is shown and any 'Back' links work as expected",
+            "when the year of birth is 1890, the 'About the service person' page is shown and any 'Back' links work as expected",
         },
         {
           month: "01",


### PR DESCRIPTION
This pull request introduces the "About the service person" form to the multi-page journey and continues the flow to include a "Have you previously made a request?". Related content, validation, and tests are updated. 

**Key changes:**

**1. New "About the service person" form and flow integration**
- Added a new `ServicePersonDetails` form (`app/main/forms/service_person_details.py`) with required and optional fields and validation. The form is now rendered and validated on the `/service-person-details/` route, storing submission data in the session and progressing the state machine.
- Updated the state machine to include new states and transitions for the "About the service person" and "Have you previously made a request?" steps.

**2. Content and field updates**
- Updated `content.yaml` to provide new headings, labels, and validation messages for the new and existing fields, including splitting out first and middle name fields and updating the "died in service" label.

**3. New and updated templates**
- Added a new template for the "Have you previously made a request?" page and updated the service person details template to use the new form, display validation errors, and render all form fields.

**4. State machine and route wiring**
- Updated routes and state machine logic to wire up the new form and ensure correct navigation and state transitions, including session management and progression to the new steps.

**5. Comprehensive test coverage**
- Added new Playwright end-to-end tests for the "About the service person" form, including validation and navigation scenarios. Updated and expanded state machine and integration tests to cover the new flow and ensure correct behavior. 