### PR TITLE
Add 'Have you previously made a request?' form

### DIFF
--- a/app/constants.py
+++ b/app/constants.py
@@ -28,6 +28,7 @@ class MultiPageFormRoutes(Enum):
     DO_YOU_HAVE_A_PROOF_OF_DEATH = "main.do_you_have_a_proof_of_death"
     UPLOAD_A_PROOF_OF_DEATH = "main.upload_a_proof_of_death"
     HAVE_YOU_PREVIOUSLY_MADE_A_REQUEST = "main.have_you_previously_made_a_request"
+    YOUR_DETAILS = "main.your_details"
 
 
 class ServiceBranches(Enum):

--- a/app/content/content.yaml
+++ b/app/content/content.yaml
@@ -180,6 +180,8 @@ pages:
     heading: Payment incomplete
     paragraphs:
       - Your payment was not completed successfully.
+  your_details:
+    heading: Your details
 forms:
   fields:
     start_now:
@@ -269,6 +271,14 @@ forms:
       label: Did they die in service? (optional)
       messages:
         required: Choosing an option for death in service is required
+    have_you_previously_made_a_request:
+      with_mod:
+        label: Have you made a request for this record with the Ministry of Defence before? (optional)
+        hint_text: If so, please provide your reference number. This might start with 'APV' followed by a series of numbers.
+      with_tna:
+        label: Have you made a request for this record with us before? (optional)
+        hint_text: If so, provide your case reference number. This might start with 'CAS' or 'SPR' followed by a series of numbers.
+      call_to_action: Continue
     case_reference_number:
       label: Case reference number (optional)
       description: If you have contacted us before and have a case reference number, please enter it here. This might start with 'CAS' or 'SPR'

--- a/app/lib/state_machine/state_machine.py
+++ b/app/lib/state_machine/state_machine.py
@@ -80,6 +80,7 @@ class RoutingStateMachine(StateMachine):
     have_you_previously_made_a_request_form = State(
         enter="entering_have_you_previously_made_a_request_form", final=True
     )
+    your_details_form = State(enter="entering_your_details_form", final=True)
 
     """
     These are our Events. They're called in route methods to trigger transitions between States.
@@ -141,6 +142,10 @@ class RoutingStateMachine(StateMachine):
 
     continue_from_service_person_details_form = initial.to(
         have_you_previously_made_a_request_form
+    )
+
+    continue_from_have_you_previously_made_a_request_form = initial.to(
+        your_details_form
     )
 
     def entering_have_you_checked_the_catalogue_form(self, event, state):
@@ -220,6 +225,9 @@ class RoutingStateMachine(StateMachine):
         self.route_for_current_state = (
             MultiPageFormRoutes.HAVE_YOU_PREVIOUSLY_MADE_A_REQUEST.value
         )
+
+    def entering_your_details_form(self, form):
+        self.route_for_current_state = MultiPageFormRoutes.YOUR_DETAILS.value
 
     def on_enter_state(self, event, state):
         """This method is called when entering any state."""

--- a/app/main/forms/have_you_previously_made_a_request.py
+++ b/app/main/forms/have_you_previously_made_a_request.py
@@ -1,0 +1,45 @@
+from app.lib.content import get_field_content, load_content
+from flask_wtf import FlaskForm
+from tna_frontend_jinja.wtforms import (
+    TnaSubmitWidget,
+    TnaTextInputWidget,
+)
+from tna_frontend_jinja.wtforms import validators as tna_frontend_validators
+from wtforms import (
+    StringField,
+    SubmitField,
+)
+from wtforms.validators import Email, InputRequired
+
+
+class HaveYouPreviouslyMadeARequest(FlaskForm):
+    content = load_content()
+
+    with_mod = StringField(
+        get_field_content(content, "have_you_previously_made_a_request", "with_mod")[
+            "label"
+        ],
+        description=get_field_content(
+            content, "have_you_previously_made_a_request", "with_mod"
+        )["hint_text"],
+        widget=TnaTextInputWidget(),
+        validators=[],
+    )
+
+    with_tna = StringField(
+        get_field_content(content, "have_you_previously_made_a_request", "with_tna")[
+            "label"
+        ],
+        description=get_field_content(
+            content, "have_you_previously_made_a_request", "with_tna"
+        )["hint_text"],
+        widget=TnaTextInputWidget(),
+        validators=[],
+    )
+
+    submit = SubmitField(
+        get_field_content(
+            content, "have_you_previously_made_a_request", "call_to_action"
+        ),
+        widget=TnaSubmitWidget(),
+    )

--- a/app/main/routes/routes_multiple_forms_journey.py
+++ b/app/main/routes/routes_multiple_forms_journey.py
@@ -6,6 +6,9 @@ from app.lib.decorators.with_form_prefilled_from_session import (
 from app.main import bp
 from app.main.forms.do_you_have_a_proof_of_death import DoYouHaveAProofOfDeath
 from app.main.forms.have_you_checked_the_catalogue import HaveYouCheckedTheCatalogue
+from app.main.forms.have_you_previously_made_a_request import (
+    HaveYouPreviouslyMadeARequest,
+)
 from app.main.forms.is_service_person_alive import IsServicePersonAlive
 from app.main.forms.service_branch import ServiceBranch
 from app.main.forms.start_now import StartNow
@@ -206,11 +209,31 @@ def service_person_details(form, state_machine):
     )
 
 
-@bp.route("/have-you-previously-made-a-request/", methods=["GET"])
-def have_you_previously_made_a_request():
+@bp.route("/have-you-previously-made-a-request/", methods=["GET", "POST"])
+@with_form_prefilled_from_session(HaveYouPreviouslyMadeARequest)
+@with_state_machine
+def have_you_previously_made_a_request(form, state_machine):
+    if form.validate_on_submit():
+        session["have_you_previously_made_a_request_with_mod"] = (
+            form.with_mod.data if form.with_mod.data else None
+        )
+        session["have_you_previously_made_a_request_with_tna"] = (
+            form.with_tna.data if form.with_tna.data else None
+        )
+        state_machine.continue_from_have_you_previously_made_a_request_form(form)
+        return redirect(url_for(state_machine.route_for_current_state))
+
     return render_template(
         "main/multi-page-journey/have-you-previously-made-a-request.html",
+        form=form,
         content=load_content(),
+    )
+
+
+@bp.route("/your-details/", methods=["GET"])
+def your_details():
+    return render_template(
+        "main/multi-page-journey/your-details.html", content=load_content()
     )
 
 

--- a/app/templates/main/multi-page-journey/have-you-previously-made-a-request.html
+++ b/app/templates/main/multi-page-journey/have-you-previously-made-a-request.html
@@ -9,6 +9,15 @@
       <div
         class="tna-column tna-column--width-2-3 tna-column--width-5-6-medium tna-column--full-small tna-column--full-tiny">
         <h1 class="tna-heading-xl">{{ content.pages.have_you_previously_made_a_request.heading }}</h1>
+        <form action="{{ url_for('main.have_you_previously_made_a_request') }}" method="post" novalidate>
+          {{ form.csrf_token }}
+          {{ form.with_mod(params={'size':'m'}) }}
+          {{ form.with_tna(params={'size':'m'}) }}
+          <div class="tna-button-group">
+            {{ backLink(url_for('main.service_person_details')) }}
+            {{ form.submit(params={'accent':'true'}) }}
+          </div>
+        </form>
       </div>
     </div>
   </div>

--- a/app/templates/main/multi-page-journey/your-details.html
+++ b/app/templates/main/multi-page-journey/your-details.html
@@ -1,0 +1,16 @@
+{% extends 'base.html' %}
+
+{%- set pageTitle = content.app.title -%}
+
+{% block content %}
+  {{ modFoiBreadcrumbs({'breadcrumbItems': breadcrumbItems}) }}
+  <div class="tna-section">
+    <div class="tna-container">
+      <div
+        class="tna-column tna-column--width-2-3 tna-column--width-5-6-medium tna-column--full-small tna-column--full-tiny">
+        <h1 class="tna-heading-xl">{{ content.pages.your_details.heading }}</h1>
+      </div>
+    </div>
+  </div>
+  </div>
+{% endblock %}

--- a/test/main/test_state_machine.py
+++ b/test/main/test_state_machine.py
@@ -59,7 +59,7 @@ def test_continue_from_have_you_checked_the_catalogue_form_routes_by_condition(
 ):
     sm = RoutingStateMachine()
     sm.continue_from_have_you_checked_the_catalogue_form(
-        form=make_form("have_you_checked_the_catalogue", answer)
+        form=make_form(have_you_checked_the_catalogue=answer)
     )
     assert sm.current_state.id == expected_state
     assert sm.route_for_current_state == expected_route
@@ -81,7 +81,7 @@ def test_continue_from_service_person_alive_form_routes_by_condition(
 ):
     sm = RoutingStateMachine()
     sm.continue_from_service_person_alive_form(
-        form=make_form("is_service_person_alive", answer)
+        form=make_form(is_service_person_alive=answer)
     )
     assert sm.current_state.id == expected_state
     assert sm.route_for_current_state == expected_route
@@ -126,7 +126,7 @@ def test_continue_from_service_branch_form_routes_by_condition(
     answer, expected_state, expected_route
 ):
     sm = RoutingStateMachine()
-    sm.continue_from_service_branch_form(form=make_form("service_branch", answer))
+    sm.continue_from_service_branch_form(form=make_form(service_branch=answer))
     assert sm.current_state.id == expected_state
     assert sm.route_for_current_state == expected_route
 
@@ -156,7 +156,7 @@ def test_continue_from_was_service_person_an_officer_form_routes_by_condition(
 ):
     sm = RoutingStateMachine()
     sm.continue_from_was_service_person_an_officer_form(
-        form=make_form("was_service_person_an_officer", answer)
+        form=make_form(was_service_person_an_officer=answer)
     )
     assert sm.current_state.id == expected_state
     assert sm.route_for_current_state == expected_route
@@ -165,7 +165,7 @@ def test_continue_from_was_service_person_an_officer_form_routes_by_condition(
 def test_continue_from_we_may_hold_this_record():
     sm = RoutingStateMachine()
     sm.continue_from_we_may_hold_this_record_form(
-        form=make_form("we_may_hold_this_record")
+        form=make_form(we_may_hold_this_record=None)
     )
     assert sm.current_state.id == "what_was_their_date_of_birth_form"
     assert (
@@ -214,7 +214,7 @@ def test_continue_from_what_was_their_date_of_birth_form(
 ):
     sm = RoutingStateMachine()
     sm.continue_from_what_was_their_date_of_birth_form(
-        form=make_form("what_was_their_date_of_birth", date_of_birth)
+        form=make_form(what_was_their_date_of_birth=date_of_birth)
     )
     assert sm.current_state.id == expected_state
     assert sm.route_for_current_state == expected_route
@@ -240,7 +240,7 @@ def test_continue_from_do_you_have_a_proof_of_death(
 ):
     sm = RoutingStateMachine()
     sm.continue_from_do_you_have_a_proof_of_death_form(
-        form=make_form("upload_a_proof_of_death", has_proof_of_death)
+        form=make_form(upload_a_proof_of_death=has_proof_of_death)
     )
     assert sm.current_state.id == expected_state
     assert sm.route_for_current_state == expected_route
@@ -249,7 +249,7 @@ def test_continue_from_do_you_have_a_proof_of_death(
 def test_continue_from_upload_a_proof_of_death():
     sm = RoutingStateMachine()
     sm.continue_from_upload_a_proof_of_death_form(
-        form=make_form("upload_a_proof_of_death")
+        form=make_form(upload_a_proof_of_death=None)
     )
     assert sm.current_state.id == "service_person_details_form"
     assert sm.route_for_current_state == "main.service_person_details"
@@ -258,7 +258,7 @@ def test_continue_from_upload_a_proof_of_death():
 def test_continue_from_service_person_details():
     sm = RoutingStateMachine()
     sm.continue_from_service_person_details_form(
-        form=make_form("service_person_details")
+        form=make_form(service_person_details=None)
     )
     assert sm.current_state.id == "have_you_previously_made_a_request_form"
     assert (
@@ -267,5 +267,24 @@ def test_continue_from_service_person_details():
     )
 
 
-def make_form(field_name: str, answer: str = None):
-    return SimpleNamespace(**{field_name: SimpleNamespace(data=answer)})
+def test_continue_from_have_you_previously_made_a_request():
+    sm = RoutingStateMachine()
+
+    sm.continue_from_have_you_previously_made_a_request_form(
+        form=make_form(
+            first_name=None,
+            middle_names=None,
+            last_name=None,
+            place_of_birth=None,
+            date_of_death=None,
+            died_in_service=None,
+            service_number=None,
+            regiment=None,
+            additional_information=None,
+            submit=None,
+        )
+    )
+
+
+def make_form(**fields):
+    return SimpleNamespace(**{k: SimpleNamespace(data=v) for k, v in fields.items()})

--- a/test/playwright/multi-page-journey/have-you-previously-made-a-request.spec.ts
+++ b/test/playwright/multi-page-journey/have-you-previously-made-a-request.spec.ts
@@ -1,0 +1,37 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("have you previously made a request", () => {
+  const basePath = "/request-a-service-record";
+  enum Urls {
+    START_PAGE = `${basePath}/start/`,
+    HAVE_YOU_PREVIOUSLY_MADE_A_REQUEST = `${basePath}/have-you-previously-made-a-request/`,
+    YOUR_DETAILS = `${basePath}/your-details/`,
+    SERVICE_PERSON_DETAILS = `${basePath}/service-person-details/`,
+  }
+
+  test.beforeEach(async ({ page }) => {
+    await page.goto(Urls.START_PAGE);
+    await page.goto(Urls.HAVE_YOU_PREVIOUSLY_MADE_A_REQUEST);
+  });
+
+  test("has the correct heading", async ({ page }) => {
+    await expect(page.locator("h1")).toHaveText(
+      /Have you previously made a request/,
+    );
+  });
+
+  test.describe("when submitted", () => {
+    test("the user is taken to the 'Your details' page", async ({ page }) => {
+      await page.getByRole("button", { name: /Continue/i }).click();
+      await expect(page).toHaveURL(Urls.YOUR_DETAILS);
+      await expect(page.locator("h1")).toHaveText(/Your details/);
+    });
+
+    test("clicking 'Back' from 'Have you previously made a request?' brings the user back to the 'Service person details' page", async ({
+      page,
+    }) => {
+      await page.getByRole("link", { name: "Back" }).click();
+      await expect(page).toHaveURL(Urls.SERVICE_PERSON_DETAILS);
+    });
+  });
+});


### PR DESCRIPTION
This pull request introduces a new step to the multi-page journey, allowing users to provide any reference numbers associated with a previous request. If the do, or do not, clicking "Continue" and transitions them to a new "Your details" page (which will be populated in a subsequent PR). 

The changes include adding the new form, updating the state machine and routes, templates, and expanding Pytest and Playwright tests to cover the new flow.

## New multi-page journey step

* Added a new `HaveYouPreviouslyMadeARequest` form (`app/main/forms/have_you_previously_made_a_request.py`) and integrated it into the journey, allowing users to provide reference numbers for previous requests with the Ministry of Defence or The National Archives.
* Updated the state machine to include a new state and transition for the "Your details" step, and to handle the new form submission and routing logic.

## Routing and content updates

* Modified routes to handle GET/POST for the new form, store responses in the session, and redirect to the new "Your details" page. Added a route and template for the "Your details" page.
* Updated the "Have you previously made a request?" template to use the new WTForms-based form and improved navigation controls.

## Testing enhancements

* Added Playwright end-to-end tests to verify the new step, including navigation and form submission behavior.
* Refactored and extended state machine unit tests to cover the new form and transition, and improved the `make_form` helper for better flexibility.