### PR TITLE
Add 'How do you want your order processed?' form and routing to GOV.UK Pay

### DIFF
--- a/app/constants.py
+++ b/app/constants.py
@@ -31,6 +31,7 @@ class MultiPageFormRoutes(Enum):
     YOUR_DETAILS = "main.your_details"
     YOUR_POSTAL_ADDRESS = "main.your_postal_address"
     HOW_DO_YOU_WANT_YOUR_ORDER_PROCESSED = "main.how_do_you_want_your_order_processed"
+    SEND_TO_GOV_PAY = "main.send_to_gov_pay"
 
 
 class ServiceBranches(Enum):

--- a/app/content/content.yaml
+++ b/app/content/content.yaml
@@ -185,6 +185,34 @@ pages:
       - Please provide a postal address so we can contact you.
   how_do_you_want_your_order_processed:
     heading: How do you want your order processed?
+    paragraphs:
+      - There are two ways to request a record from us.
+    order_type_one:
+      heading: Standard
+      sub_heading: (Recommended)
+      paragraphs:
+        - |
+          Standard provides a subset of documents in the record. 
+          It will include information that would be of most interest to 
+          the families of service person, such as details provided when 
+          they enlisted, records of service and testimonials.
+      table_rows:
+        - header: When you'll get the record
+          data: We cannot confirm when you will receive the record. However, we will aim to respond to your request within 30 working days.
+        - header: ████ ██████ ███
+          data: █████ ██ ██████ ██ ██████ ████ ██████ ███
+    order_type_two:
+      heading: Full sensitivity check
+      paragraphs:
+        - |
+          Documents not provided in our standard subset will, in most cases, contain sensitive information and will be closed by default. 
+          However, we can complete a full sensitivity check of the record to assess what can be
+          released. In some cases, we will not be able to supply the record at all, or large parts of it will be redacted.
+      table_rows:
+        - header: When you'll get the record
+          data: We cannot confirm when you will receive the record. However, we will aim to respond to your request within 30 working days.
+        - header: ████ ██████ ███
+          data: █████ ██ ██████ ████ ██████ ███
 forms:
   fields:
     start_now:
@@ -327,3 +355,17 @@ forms:
         required: Country is required
     proceed_to_payment:
       call_to_action: Proceed to make payment using GOV.UK Pay
+    how_do_you_want_your_order_processed:
+      label: Please choose a format
+      standard:
+        label: Standard
+        digital: Digital standard
+        printed: Printed standard
+        continue: Continue with a standard order
+      full:
+        label: Full check
+        digital: Digital full record check
+        printed: Printed full record check
+        continue: Continue with a full record check order
+      messages:
+        no_radio_selected: You must select a processing option to continue

--- a/app/lib/decorators/with_form_prefilled_from_session.py
+++ b/app/lib/decorators/with_form_prefilled_from_session.py
@@ -13,7 +13,11 @@ def with_form_prefilled_from_session(form_class):
                 form_data = session.get("form_data", {})
                 if not isinstance(form_data, dict):
                     form_data = {}
-                data = {k: v for k, v in form_data.items() if k not in excluded_form_data_fields}
+                data = {
+                    k: v
+                    for k, v in form_data.items()
+                    if k not in excluded_form_data_fields
+                }
                 form = form_class(data=data)
             else:
                 form = form_class()

--- a/app/lib/state_machine/state_machine.py
+++ b/app/lib/state_machine/state_machine.py
@@ -87,6 +87,7 @@ class RoutingStateMachine(StateMachine):
     how_do_you_want_your_order_processed_form = State(
         enter="entering_how_do_you_want_your_order_processed_form", final=True
     )
+    gov_uk_pay_redirect = State(enter="entering_gov_uk_pay_redirect", final=True)
 
     """
     These are our Events. They're called in route methods to trigger transitions between States.
@@ -157,6 +158,14 @@ class RoutingStateMachine(StateMachine):
     continue_from_your_details_form = initial.to(
         your_postal_address_form, cond="does_not_have_email"
     ) | initial.to(how_do_you_want_your_order_processed_form)
+
+    continue_from_your_postal_address_form = initial.to(
+        how_do_you_want_your_order_processed_form
+    )
+
+    continue_from_how_do_you_want_your_order_processed_form = initial.to(
+        gov_uk_pay_redirect
+    )
 
     def entering_have_you_checked_the_catalogue_form(self, event, state):
         self.route_for_current_state = (
@@ -246,6 +255,9 @@ class RoutingStateMachine(StateMachine):
         self.route_for_current_state = (
             MultiPageFormRoutes.HOW_DO_YOU_WANT_YOUR_ORDER_PROCESSED.value
         )
+
+    def entering_gov_uk_pay_redirect(self, form):
+        self.route_for_current_state = MultiPageFormRoutes.SEND_TO_GOV_PAY.value
 
     def on_enter_state(self, event, state):
         """This method is called when entering any state."""

--- a/app/main/forms/how_do_you_want_your_order_processed.py
+++ b/app/main/forms/how_do_you_want_your_order_processed.py
@@ -1,0 +1,99 @@
+from app.lib.content import get_field_content, load_content
+from flask_wtf import FlaskForm
+from tna_frontend_jinja.wtforms import (
+    TnaRadiosWidget,
+    TnaSubmitWidget,
+)
+from wtforms import (
+    RadioField,
+    SubmitField,
+)
+
+from app.main.forms.validation_helpers.radio_conditionally_required import (
+    radio_conditionally_required,
+)
+
+
+class HowDoYouWantYourOrderProcessed(FlaskForm):
+    content = load_content()
+
+    # This field is not exposed to the user. It is used to determine which option the form
+    # is relevant to (standard or full) for validation purposes. For example, if the user has submitted
+    # the standard option, the standard radio field is required, but the full option is not.
+    processing_option = RadioField(
+        "",
+        choices=["standard", "full"],
+        validators=[],
+        validate_choice=False,
+    )
+
+    how_do_you_want_your_order_processed_standard_option = RadioField(
+        get_field_content(content, "how_do_you_want_your_order_processed", "label"),
+        choices=[
+            (
+                "digital",
+                get_field_content(
+                    content, "how_do_you_want_your_order_processed", "standard"
+                )["digital"],
+            ),
+            (
+                "printed",
+                get_field_content(
+                    content, "how_do_you_want_your_order_processed", "standard"
+                )["printed"],
+            ),
+        ],
+        validators=[
+            radio_conditionally_required(
+                other_field_name="processing_option",
+                other_field_value="standard",
+                message=get_field_content(
+                    content, "how_do_you_want_your_order_processed", "messages"
+                )["no_radio_selected"],
+            )
+        ],
+        validate_choice=False,
+        widget=TnaRadiosWidget(),
+    )
+
+    how_do_you_want_your_order_processed_full_option = RadioField(
+        get_field_content(content, "how_do_you_want_your_order_processed", "label"),
+        choices=[
+            (
+                "digital",
+                get_field_content(
+                    content, "how_do_you_want_your_order_processed", "full"
+                )["digital"],
+            ),
+            (
+                "printed",
+                get_field_content(
+                    content, "how_do_you_want_your_order_processed", "full"
+                )["printed"],
+            ),
+        ],
+        validators=[
+            radio_conditionally_required(
+                other_field_name="processing_option",
+                other_field_value="full",
+                message=get_field_content(
+                    content, "how_do_you_want_your_order_processed", "messages"
+                )["no_radio_selected"],
+            )
+        ],
+        validate_choice=False,
+        widget=TnaRadiosWidget(),
+    )
+
+    submit_standard = SubmitField(
+        get_field_content(content, "how_do_you_want_your_order_processed", "standard")[
+            "continue"
+        ],
+        widget=TnaSubmitWidget(),
+    )
+    submit_full_check = SubmitField(
+        get_field_content(content, "how_do_you_want_your_order_processed", "full")[
+            "continue"
+        ],
+        widget=TnaSubmitWidget(),
+    )

--- a/app/main/forms/validation_helpers/radio_conditionally_required.py
+++ b/app/main/forms/validation_helpers/radio_conditionally_required.py
@@ -1,0 +1,37 @@
+from wtforms.validators import ValidationError
+
+
+def radio_conditionally_required(
+    other_field_name=None, other_field_value=None, message=None
+):
+    """
+    Returns a WTForms validator that makes the current field required only if another
+    field (identified by `other_field_name`) has a specific value (`other_field_value`).
+
+    Parameters:
+        other_field_name (str): Name of the sibling field whose value we inspect.
+        other_field_value (Any): Value that triggers the requirement.
+        message (str): Error message raised if requirement is not met.
+
+    Behavior:
+        - If the other field does not exist on the form, validator silently does nothing.
+        - If the other field's value equals `other_field_value` AND current field is empty,
+          a ValidationError is raised.
+        - Otherwise, validation passes.
+    """
+    if message is None:
+        message = "This field is required."
+
+    def _validator(form, field):
+        # Attempt to get the other_field from the form
+        other_field = getattr(form, other_field_name, None)
+        # Fail silently if other_field does not exist
+        if other_field is None:
+            return
+        # The key logic:
+        # if other_field has the specified value and current field is empty,
+        # raise a ValidationError
+        if other_field.data == other_field_value and not field.data:
+            raise ValidationError(message)
+
+    return _validator

--- a/app/main/routes/routes_multiple_forms_journey.py
+++ b/app/main/routes/routes_multiple_forms_journey.py
@@ -22,6 +22,9 @@ from app.main.forms.what_was_their_date_of_birth import WhatWasTheirDateOfBirth
 from app.main.forms.upload_a_proof_of_death import UploadAProofOfDeath
 from app.main.forms.service_person_details import ServicePersonDetails
 from app.main.forms.your_postal_address import YourPostalAddress
+from app.main.forms.how_do_you_want_your_order_processed import (
+    HowDoYouWantYourOrderProcessed,
+)
 from app.main.forms.your_details import YourDetails
 from flask import redirect, render_template, session, url_for
 
@@ -257,7 +260,9 @@ def do_you_have_a_proof_of_death(form, state_machine):
 @with_state_machine
 def your_postal_address(form, state_machine):
     if form.validate_on_submit():
-        pass
+        save_submitted_form_fields_to_session(form)
+        state_machine.continue_from_your_postal_address_form(form)
+        return redirect(url_for(state_machine.route_for_current_state))
     return render_template(
         "main/multi-page-journey/your-postal-address.html",
         form=form,
@@ -265,10 +270,17 @@ def your_postal_address(form, state_machine):
     )
 
 
-@bp.route("/how-do-you-want-your-order-processed/", methods=["GET"])
-def how_do_you_want_your_order_processed():
+@bp.route("/how-do-you-want-your-order-processed/", methods=["GET", "POST"])
+@with_state_machine
+def how_do_you_want_your_order_processed(state_machine):
+    form = HowDoYouWantYourOrderProcessed()
+    if form.validate_on_submit():
+        save_submitted_form_fields_to_session(form)
+        state_machine.continue_from_how_do_you_want_your_order_processed_form(form)
+        return redirect(url_for(state_machine.route_for_current_state))
     return render_template(
         "main/multi-page-journey/how-do-you-want-your-order-processed.html",
+        form=form,
         content=load_content(),
     )
 

--- a/app/templates/main/multi-page-journey/how-do-you-want-your-order-processed.html
+++ b/app/templates/main/multi-page-journey/how-do-you-want-your-order-processed.html
@@ -8,7 +8,72 @@
     <div class="tna-container">
       <div
         class="tna-column tna-column--width-2-3 tna-column--width-5-6-medium tna-column--full-small tna-column--full-tiny">
+        {% if form.errors %}
+          {{ tnaErrorSummary(wtforms_errors(form)) }}
+        {% endif %}
         <h1 class="tna-heading-xl">{{ content.pages.how_do_you_want_your_order_processed.heading }}</h1>
+        {% for paragraph in content.pages.how_do_you_want_your_order_processed.paragraphs %}
+          <p>{{ paragraph }}</p>
+        {% endfor %}
+        <h2 class="tna-heading-l">
+          {{ content.pages.how_do_you_want_your_order_processed.order_type_one.heading }}<br>
+          <span
+            class="tna-heading-s">{{ content.pages.how_do_you_want_your_order_processed.order_type_one.sub_heading }}</span>
+        </h2>
+        {% for paragraph in content.pages.how_do_you_want_your_order_processed.order_type_one.paragraphs %}
+          <p>{{ paragraph }}</p>
+        {% endfor %}
+        {% if content.pages.how_do_you_want_your_order_processed.order_type_one.table_rows %}
+          <table class="tna-table">
+            {% for row in content.pages.how_do_you_want_your_order_processed.order_type_one.table_rows %}
+              <tr class="tna-table__row">
+                <th class="tna-table__header">{{ row.header }}</th>
+                <td class="tna-table__cell tna-table__cell--numeric">{{ row.data }}</td>
+              </tr>
+            {% endfor %}
+          </table>
+        {% endif %}
+
+
+        <form action="{{ url_for('main.how_do_you_want_your_order_processed') }}" method="post" novalidate
+              class="form-separator">
+          {{ form.csrf_token }}
+          {# The processing_option fields are hard-coded to allow a single HowDoYouWantYourOrderProcessed form to be reused in the page #}
+          <input type="hidden" name="processing_option" value="standard"/>
+          {{ form.how_do_you_want_your_order_processed_standard_option() }}
+          <div class="tna-button-group">
+            {{ form.submit_standard(params={'accent':'true'}) }}
+          </div>
+        </form>
+
+        <h2 class="tna-heading-l">
+          {{ content.pages.how_do_you_want_your_order_processed.order_type_two.heading }}
+        </h2>
+
+        {% for paragraph in content.pages.how_do_you_want_your_order_processed.order_type_two.paragraphs %}
+          <p>{{ paragraph }}</p>
+        {% endfor %}
+
+        {% if content.pages.how_do_you_want_your_order_processed.order_type_two.table_rows %}
+          <table class="tna-table">
+            {% for row in content.pages.how_do_you_want_your_order_processed.order_type_two.table_rows %}
+              <tr class="tna-table__row">
+                <th class="tna-table__header">{{ row.header }}</th>
+                <td class="tna-table__cell tna-table__cell--numeric">{{ row.data }}</td>
+              </tr>
+            {% endfor %}
+          </table>
+        {% endif %}
+
+        <form action="{{ url_for('main.how_do_you_want_your_order_processed') }}" method="post" novalidate>
+          {{ form.csrf_token }}
+          {# The processing_option fields are hard-coded to allow a single HowDoYouWantYourOrderProcessed form to be reused in the page #}
+          <input type="hidden" name="processing_option" value="full"/>
+          {{ form.how_do_you_want_your_order_processed_full_option() }}
+          <div class="tna-button-group">
+            {{ form.submit_full_check(params={'accent':'true'}) }}
+          </div>
+        </form>
       </div>
     </div>
   </div>

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -6,3 +6,9 @@
     @include a11y.visually-hidden;
   }
 }
+
+.form-separator {
+  border-block-end: 3px solid black;
+
+  padding-bottom: 3rem;
+}

--- a/test/playwright/multi-page-journey/how-do-you-want-your-order-processed.spec.ts
+++ b/test/playwright/multi-page-journey/how-do-you-want-your-order-processed.spec.ts
@@ -1,0 +1,80 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("how do you want your order processed", () => {
+  const basePath = "/request-a-service-record";
+
+  enum Urls {
+    START_PAGE = `${basePath}/start/`,
+    YOUR_POSTAL_ADDRESS = `${basePath}/how-do-you-want-your-order-processed/`,
+  }
+
+  test.beforeEach(async ({ page }) => {
+    await page.goto(Urls.START_PAGE);
+    await page.goto(Urls.YOUR_POSTAL_ADDRESS);
+  });
+
+  test("has the correct heading", async ({ page }) => {
+    await expect(page.locator("h1")).toHaveText(
+      /How do you want your order processed?/,
+    );
+  });
+
+  test.describe("when submitted", () => {
+    test.describe("the 'standard' order form option", () => {
+      test("without any fields selected, shows the correct error message", async ({
+        page,
+      }) => {
+        await page
+          .getByRole("button", { name: /Continue with a standard order/i })
+          .click();
+        await expect(page.locator(".tna-form__error-message")).toHaveCount(1);
+        await expect(
+          page.locator(".tna-form__error-message").first(),
+        ).toHaveText(/You must select a processing option to continue/);
+      });
+      ["Digital standard", "Printed standard"].forEach((option) => {
+        test(`with "${option}" selected, there is no error`, async ({
+          page,
+        }) => {
+          await page.getByLabel(option).check();
+          await page
+            .getByRole("button", { name: /Continue with a standard order/i })
+            .click();
+          await expect(page.locator(".tna-form__error-message")).toHaveCount(0);
+        });
+      });
+    });
+    test.describe("the 'full' order form option", () => {
+      test("without any fields selected, shows the correct error message", async ({
+        page,
+      }) => {
+        await page
+          .getByRole("button", {
+            name: /Continue with a full record check order/i,
+          })
+          .click();
+        await expect(page.locator(".tna-form__error-message")).toHaveCount(1);
+        await expect(
+          page.locator(".tna-form__error-message").first(),
+        ).toHaveText(/You must select a processing option to continue/);
+      });
+      ["Digital full record check", "Printed full record check"].forEach(
+        (option) => {
+          test(`with "${option}" selected, there is no error`, async ({
+            page,
+          }) => {
+            await page.getByLabel(option).check();
+            await page
+              .getByRole("button", {
+                name: /Continue with a full record check order/i,
+              })
+              .click();
+            await expect(page.locator(".tna-form__error-message")).toHaveCount(
+              0,
+            );
+          });
+        },
+      );
+    });
+  });
+});

--- a/test/playwright/multi-page-journey/your-postal-address.spec.ts
+++ b/test/playwright/multi-page-journey/your-postal-address.spec.ts
@@ -32,6 +32,15 @@ test.describe("your postal address", () => {
       );
     });
 
+    test("with the form completed, takes the user to the 'How do you want your order processed?' page", async ({
+      page,
+    }) => {
+      await page.getByLabel("Address Line 1").fill("123 Non-existent Road");
+      await page.getByLabel("Town or city").fill("Non-existent Town");
+      await page.getByRole("button", { name: /Continue/i }).click();
+      await expect(page).toHaveURL(/how-do-you-want-your-order-processed/);
+    });
+
     test("clicking 'Back' from 'Your postal address' brings the user back to the 'Your details' page", async ({
       page,
     }) => {


### PR DESCRIPTION
This pull request introduces a new "How do you want your order processed?" step to the multi-page journey, allowing users to choose between a standard order or a full record check for their request. It covers state machine updates, a new WTForms-powered form with conditional validation, content and template changes for the new step, and comprehensive tests (including Playwright E2E tests and Pytest unit tests for the state machine transitions) to ensure correct user flow and error handling.

Key changes include:

## New form

* Added a new `HowDoYouWantYourOrderProcessed` form with conditional radio validation to let users choose between "standard" and "full" options, each supporting digital or printed formats
* Updated state machine to support the new form and the redirect to GOV.UK Pay after submission

## Routing and Flow Updates

* Modified routes to handle the new form's GET and POST logic, saving form data to the session and progressing state as appropriate.

## Testing

* Added unit tests for the new state machine transitions and form logic, including validation and route correctness
* Added Playwright E2E test for the journey to, within and from the new form

## Other Improvements

* Improved code formatting.