### PR TITLE
Add 'Other last names' field to service person details form

### DIFF
--- a/app/main/forms/service_person_details.py
+++ b/app/main/forms/service_person_details.py
@@ -46,6 +46,12 @@ class ServicePersonDetails(FlaskForm):
         ],
     )
 
+    other_last_names = StringField(
+        get_field_content(content, "other_last_names", "label"),
+        widget=TnaTextInputWidget(),
+        validators=[],
+    )
+
     place_of_birth = StringField(
         get_field_content(content, "place_of_birth", "label"),
         widget=TnaTextInputWidget(),

--- a/app/templates/main/multi-page-journey/service-person-details.html
+++ b/app/templates/main/multi-page-journey/service-person-details.html
@@ -17,6 +17,7 @@
           {{ form.first_name(params={'headingLevel':2, 'size':'l', 'autocomplete':'off'}) }}
           {{ form.middle_names(params={'headingLevel':2, 'size':'m', 'autocomplete':'off'}) }}
           {{ form.last_name(params={'headingLevel':2, 'size':'m', 'autocomplete':'off'}) }}
+          {{ form.other_last_names(params={'headingLevel':2, 'size':'m', 'autocomplete':'off'}) }}
           {{ form.place_of_birth(params={'headingLevel':2, 'size':'m', 'autocomplete':'off'}) }}
           {{ form.date_of_death(params={'headingLevel':2, 'autocomplete':'off'}) }}
           {{ form.died_in_service(params={'headingLevel':2}) }}

--- a/test/playwright/multi-page-journey/service-person-details.spec.ts
+++ b/test/playwright/multi-page-journey/service-person-details.spec.ts
@@ -46,7 +46,7 @@ test.describe("the 'About the service person form?' form", () => {
         page,
       }) => {
         await page.getByLabel("First name").fill("Thomas");
-        await page.getByLabel("Last name").fill("Duffus");
+        await page.getByLabel("Last name", { exact: true }).fill("Duffus");
         await page.getByRole("button", { name: /Continue/i }).click();
         await expect(page).toHaveURL(Urls.HAVE_YOU_PREVIOUSLY_MADE_A_REQUEST);
       });
@@ -55,7 +55,7 @@ test.describe("the 'About the service person form?' form", () => {
       }) => {
         await page.getByLabel("First name").fill("Thomas");
         await page.getByLabel("Middle names").fill("Duffus");
-        await page.getByLabel("Last name").fill("Hardy");
+        await page.getByLabel("Last name", { exact: true }).fill("Hardy");
         await page.getByLabel("Service number").fill("123456");
         await page.getByRole("button", { name: /Continue/i }).click();
         await expect(page).toHaveURL(Urls.HAVE_YOU_PREVIOUSLY_MADE_A_REQUEST);


### PR DESCRIPTION
This pull request adds support requested by the Product Owner today for capturing "other last names" in the service person details form. 

It updates the corresponding template to display the new field, and adjusts the Playwright tests to avoid ambiguity when selecting the "Last name" field. 

The most important changes are listed below:

* Added a new `other_last_names` field to the `ServicePersonDetails` form in `service_person_details.py` to allow users to enter additional last names.
* Updated the `service-person-details.html` template to render the new `other_last_names` field in the form.
* Modified Playwright tests in `service-person-details.spec.ts` to use `{ exact: true }` when selecting the "Last name" field, preventing conflicts with the new "Other last names" field.