### PR TITLE
FOI-284: Add research invitation for Army Officer records

### DIFF
--- a/app/constants.py
+++ b/app/constants.py
@@ -99,6 +99,7 @@ class ExternalLinks:
     INDIAN_ARMY_PERSONNEL_RESEARCH_GUIDE = "https://www.nationalarchives.gov.uk/help-with-your-research/research-guides/indian-army-personnel/"
     BRITISH_ARMY_FIRST_WORLD_WAR_RESEARCH_GUIDE = "https://www.nationalarchives.gov.uk/help-with-your-research/research-guides/british-army-soldiers-of-the-first-world-war/"
     CONTACT_US = "https://www.nationalarchives.gov.uk/contact-us/"
+    OFFICER_ENDPOINT_SURVEY = "https://www.smartsurvey.co.uk/s/1KKGX5/"
 
 
 FALLBACK_COUNTRY_CHOICES = [

--- a/app/content/content.yaml
+++ b/app/content/content.yaml
@@ -264,6 +264,11 @@ pages:
     list:
       - Grenadier Guards
       - Welsh Guards
+    invitation_to_participate_in_research:
+      heading: Register to take part in a research session (opens in new tab)
+      body:
+        We are looking for people who are requesting records for Commissioned Officers.
+        Help us develop this part of the service and receive a voucher for your time.
     call_to_action: Request from the Ministry of Defence
   we_do_not_have_records_for_people_born_after:
     heading: We do not have records for people born after 1939

--- a/app/main/routes/routes.py
+++ b/app/main/routes/routes.py
@@ -243,6 +243,7 @@ def we_are_unlikely_to_hold_officer_records__army(form, state_machine):
         content=load_content(),
         form=form,
         mod_service_link=ExternalLinks.MOD_SERVICE_DECEASED_SERVICEPERSON,
+        invitation_to_participate_in_research_link=ExternalLinks.OFFICER_ENDPOINT_SURVEY,
     )
 
 

--- a/app/templates/macros/researchInvitation.html
+++ b/app/templates/macros/researchInvitation.html
@@ -1,0 +1,14 @@
+{% macro researchInvitation(headingText, linkUrl, bodyText) %}
+  <div
+    class="tna-!--margin-top-l tna-!--padding-vertical-xs tna-!--margin-top-s tna-card--horizontal tna-card--padded tna-background-tint">
+    <hgroup class="tna-hgroup-s tna-card__heading">
+      <h2 class="tna-hgroup__title">
+        <a href="{{ linkUrl }}" target="_blank" rel="noreferrer noopener"
+           class="tna-card__heading-link">{{ headingText }}</a>
+      </h2>
+    </hgroup>
+    <div class="tna-card__body">
+      <p>{{ bodyText }}</p>
+    </div>
+  </div>
+{% endmacro %}

--- a/app/templates/main/we-are-unlikely-to-hold-army-officer-records.html
+++ b/app/templates/main/we-are-unlikely-to-hold-army-officer-records.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{%- from 'macros/researchInvitation.html' import researchInvitation -%}
 
 {%- set pageTitle = content.pages.we_are_unlikely_to_hold_officer_records__army.heading | prepare_page_title -%}
 
@@ -31,6 +32,10 @@
             </a>
           </div>
         </form>
+        {{ researchInvitation(
+            content.pages.we_are_unlikely_to_hold_officer_records__army.invitation_to_participate_in_research.heading,
+            invitation_to_participate_in_research_link,
+            content.pages.we_are_unlikely_to_hold_officer_records__army.invitation_to_participate_in_research.body) }}
       </div>
     </div>
   </div>

--- a/test/playwright/state-transitions/we-are-unlikely-to-hold-officer-records__army.spec.ts
+++ b/test/playwright/state-transitions/we-are-unlikely-to-hold-officer-records__army.spec.ts
@@ -12,6 +12,16 @@ test.describe("The variant of 'We are unlikely to hold this record' for Army Off
     await page.goto(Paths.WE_ARE_UNLIKELY_TO_HOLD_OFFICER_RECORDS__ARMY);
   });
 
+  test("the link inviting users to participate in user research is correct", async ({
+    page,
+  }) => {
+    await checkExternalLink(
+      page,
+      "Register to take part in a research session (opens in new tab)",
+      "https://www.smartsurvey.co.uk/s/1KKGX5/",
+    );
+  });
+
   test("the 'Request from the Ministry of Defence' link is correct", async ({
     page,
   }) => {


### PR DESCRIPTION
This pull request updates the Army Commissioned Officer end point to introduce a new invitation for users to participate in a research session. This uses the TNA Card component and includes a link to an external survey and is covered by a new Playwright test. 

**Screenshots**

<details open>

<summary>Light mode</summary>

<img alt="image" src="https://github.com/user-attachments/assets/3748ee28-65be-4a86-839e-d2446ac7a527" />


</details>

<details open>

<summary>Dark mode</summary>

<img alt="image" src="https://github.com/user-attachments/assets/b1fd432c-b5f7-4350-9196-9513d850b579" />


</details>