### PR TITLE
FOI-293: Add British Army Officer order type page

### DIFF
--- a/app/constants.py
+++ b/app/constants.py
@@ -43,6 +43,7 @@ class MultiPageFormRoutes(Enum):
     HAVE_YOU_PREVIOUSLY_MADE_A_REQUEST = "main.have_you_previously_made_a_request"
     YOUR_CONTACT_DETAILS = "main.your_contact_details"
     WHAT_IS_YOUR_ADDRESS = "main.what_is_your_address"
+    YOUR_ORDER_TYPE_BRITISH_ARMY_OFFICER = "main.your_order_type_british_army_officers"
     CHOOSE_YOUR_ORDER_TYPE = "main.choose_your_order_type"
     YOUR_ORDER_SUMMARY = "main.your_order_summary"
     SEND_TO_GOV_UK_PAY = "main.send_to_gov_uk_pay"

--- a/app/content/content.yaml
+++ b/app/content/content.yaml
@@ -381,6 +381,37 @@ pages:
     heading: What is your address?
     paragraphs:
       - You have not provided an email address. Please provide a postal address so we can contact you about your request and, if we have the record, send it to you. There will be an extra fee for printed copies.
+  your_order_type_army_officer:
+    heading: Your order type
+    paragraphs:
+      - |
+        You are requesting a British Army Commissioned Officer record. These can only be requested with a Full record check, our Standard option is not available.
+      - |
+        As British Army Commissioned Officer records are currently being transferred to us from the Ministry of Defence, we recommend waiting until December 2026 to submit your request. By then, we anticipate most will have been transferred to us.
+    full_record_check:
+      heading: Full record check
+      paragraphs:
+        - |
+          Service records will, in most cases, contain sensitive information and will be closed to the public. However, we can complete a sensitivity check of the record to assess what can be released.
+        - |
+          In some cases, we will not be able to supply the entire record, or large parts of it will be redacted.
+        - |
+          We charge two fees for a Full record check. The first covers the search for the record and a page check. We will then email you a quote for the second payment to copy the parts of the record that can be released, priced per page. Commissioned Officer records can exceed 100 pages.
+      information_list:
+        list_items:
+          - term: What it costs
+            description:
+              - An upfront payment of £48.87, which covers the search (£38.95) and the page check (£9.92).
+              - A second payment of £1.04 per page. For example, 100 pages will cost an additional £104.
+          - term: When you will get the record
+            description:
+              - We aim to confirm if we hold the record within 30 working days. The record will be released once we have received the second payment.
+          - term: Refunds
+            description:
+              - We will refund the page check fee (£9.92) if we do not hold the record.
+              - The search fee is not refundable.
+    final_paragraphs:
+      - We will send you a digital colour scan of the record by email. You can request a printed copy by post for an extra cost.
   choose_your_order_type:
     heading: Choose your order type
     paragraphs:
@@ -677,3 +708,5 @@ forms:
       call_to_action: Go back to try the payment again
     sorry_you_will_have_to_start_again:
       call_to_action: Start again
+    your_order_type_british_army_officers:
+      call_to_action: Request a Full record check

--- a/app/lib/state_machine/state_machine.py
+++ b/app/lib/state_machine/state_machine.py
@@ -157,6 +157,10 @@ class RoutingStateMachine(StateMachine):
         enter="entering_what_is_your_address_form", final=True
     )
 
+    your_order_type_british_army_officer_form = State(
+        enter="entering_your_order_type_british_army_officer_form", final=True
+    )
+
     choose_your_order_type_form = State(
         enter="entering_choose_your_order_type_form", final=True
     )
@@ -305,14 +309,19 @@ class RoutingStateMachine(StateMachine):
     )
 
     continue_from_have_you_previously_made_a_request_form = initial.to(
-        choose_your_order_type_form
-    )
+        your_order_type_british_army_officer_form,
+        cond="was_officer and service_branch_is_army",
+    ) | initial.to(choose_your_order_type_form)
 
     continue_from_your_contact_details_form = initial.to(
         what_is_your_address_form, cond="does_not_have_email"
     ) | initial.to(your_order_summary_form)
 
     continue_from_what_is_your_address_form = initial.to(your_order_summary_form)
+
+    continue_from_your_order_type_british_army_officer_form = initial.to(
+        your_contact_details_form
+    )
 
     continue_from_choose_your_order_type_form = initial.to(your_contact_details_form)
 
@@ -453,6 +462,11 @@ class RoutingStateMachine(StateMachine):
 
     def entering_what_is_your_address_form(self):
         self.route_for_current_state = MultiPageFormRoutes.WHAT_IS_YOUR_ADDRESS.value
+
+    def entering_your_order_type_british_army_officer_form(self):
+        self.route_for_current_state = (
+            MultiPageFormRoutes.YOUR_ORDER_TYPE_BRITISH_ARMY_OFFICER.value
+        )
 
     def entering_choose_your_order_type_form(self):
         self.route_for_current_state = MultiPageFormRoutes.CHOOSE_YOUR_ORDER_TYPE.value

--- a/app/main/forms/have_you_previously_made_a_request.py
+++ b/app/main/forms/have_you_previously_made_a_request.py
@@ -13,12 +13,17 @@ from wtforms import (
     RadioField,
     StringField,
     SubmitField,
+    HiddenField,
 )
 from wtforms.validators import InputRequired, Length
 
 
 class HaveYouPreviouslyMadeARequest(FlaskForm):
     content = load_content()
+
+    service_branch = HiddenField()
+
+    were_they_a_commissioned_officer = HiddenField()
 
     have_you_previously_made_a_request = RadioField(
         get_field_content(content, "have_you_previously_made_a_request", "label"),

--- a/app/main/forms/your_order_type_british_army_officers.py
+++ b/app/main/forms/your_order_type_british_army_officers.py
@@ -1,0 +1,22 @@
+from app.lib.content import get_field_content, load_content
+from flask_wtf import FlaskForm
+from tna_frontend_jinja.wtforms import (
+    TnaSubmitWidget,
+)
+from wtforms import (
+    SubmitField,
+    HiddenField,
+)
+
+
+class YourOrderTypeBritishArmyOfficers(FlaskForm):
+    content = load_content()
+
+    processing_option = HiddenField()
+
+    submit = SubmitField(
+        get_field_content(
+            content, "your_order_type_british_army_officers", "call_to_action"
+        ),
+        widget=TnaSubmitWidget(),
+    )

--- a/app/main/routes/routes.py
+++ b/app/main/routes/routes.py
@@ -52,6 +52,10 @@ from app.main.forms.what_was_their_date_of_birth import WhatWasTheirDateOfBirth
 from app.main.forms.you_may_want_to_check_ancestry import YouMayWantToCheckAncestry
 from app.main.forms.your_contact_details import YourContactDetails
 from app.main.forms.your_order_summary import YourOrderSummary
+from app.main.forms.your_order_type_british_army_officers import (
+    YourOrderTypeBritishArmyOfficers,
+)
+
 from flask import redirect, render_template, request, session, url_for
 
 
@@ -626,6 +630,22 @@ def sorry_you_will_have_to_start_again(form, state_machine):
 
     return render_template(
         "main/sorry-you-will-have-to-start-again.html",
+        content=load_content(),
+        form=form,
+    )
+
+
+@bp.route("/your-order-type-british-army-officers/", methods=["GET", "POST"])
+@with_form_prefilled_from_session(YourOrderTypeBritishArmyOfficers)
+@with_state_machine
+def your_order_type_british_army_officers(form, state_machine):
+    if form.validate_on_submit():
+        save_submitted_form_fields_to_session(form)
+        state_machine.continue_from_your_order_type_british_army_officer_form(form)
+        return redirect(url_for(state_machine.route_for_current_state))
+
+    return render_template(
+        "main/your-order-type-british-army-officers.html",
         content=load_content(),
         form=form,
     )

--- a/app/templates/main/have-you-previously-made-a-request.html
+++ b/app/templates/main/have-you-previously-made-a-request.html
@@ -18,6 +18,8 @@
           class="tna-heading-xl tna-!--margin-top-m">{{ content.pages.have_you_previously_made_a_request.heading }}</h1>
         <form action="{{ url_for('main.have_you_previously_made_a_request') }}" method="post" novalidate>
           {{ form.csrf_token }}
+          {{ form.service_branch }}
+          {{ form.were_they_a_commissioned_officer }}
           <p>{{ content.pages.have_you_previously_made_a_request.prompt_to_provide_reference_number }}</p>
           {{ form.have_you_previously_made_a_request(params={'size':'m'}) }}
           {{ form.case_reference_number(params={'size':'m'}) }}

--- a/app/templates/main/your-order-type-british-army-officers.html
+++ b/app/templates/main/your-order-type-british-army-officers.html
@@ -1,0 +1,41 @@
+{% extends "base.html" %}
+
+{%- set pageTitle = content.pages.your_order_type_army_officer.heading | prepare_page_title -%}
+
+{% block beforeContent %}
+  {{ backLink(url_for('main.have_you_previously_made_a_request')) }}
+{% endblock beforeContent %}
+
+{% block content %}
+  <div class="tna-section tna-!--padding-top-s">
+    <div class="tna-container">
+      <div
+        class="tna-column tna-column--width-2-3 tna-column--width-5-6-medium tna-column--full-small tna-column--full-tiny">
+        <h1 class="tna-heading-xl tna-!--margin-top-m">{{ content.pages.your_order_type_army_officer.heading }}</h1>
+        {% for paragraph in content.pages.your_order_type_army_officer.paragraphs %}
+          <p>{{ paragraph }}</p>
+        {% endfor %}
+
+        <h2 class="tna-heading-l">{{ content.pages.your_order_type_army_officer.full_record_check.heading }}</h2>
+        {% for paragraph in content.pages.your_order_type_army_officer.full_record_check.paragraphs %}
+          <p>{{ paragraph }}</p>
+        {% endfor %}
+        {% if content.pages.your_order_type_army_officer.full_record_check.information_list.list_items %}
+          {{ descriptionList(content.pages.your_order_type_army_officer.full_record_check.information_list.list_items) }}
+        {% endif %}
+        {% for paragraph in content.pages.your_order_type_army_officer.final_paragraphs %}
+          <p>{{ paragraph }}</p>
+        {% endfor %}
+        <div class="tna-!--margin-top-m">
+          <form action="{{ url_for('main.your_order_type_british_army_officers') }}" method="post" novalidate>
+            {{ form.csrf_token }}
+            {{ form.processing_option(value='full', id='processing_option_full_record_check') }}
+            <div class="tna-button-group">
+              {{ form.submit(params={'classes': 'tna-button--accent'}) }}
+            </div>
+          </form>
+        </div>
+      </div>
+    </div>
+  </div>
+{% endblock content %}

--- a/test/main/test_state_machine.py
+++ b/test/main/test_state_machine.py
@@ -448,6 +448,7 @@ def test_continue_from_have_you_previously_made_a_request():
             service_number=None,
             regiment=None,
             additional_information=None,
+            were_they_a_commissioned_officer=None,
             submit=None,
         )
     )
@@ -623,3 +624,10 @@ def test_continue_from_sorry_you_will_have_to_start_again():
     )
     assert sm.current_state.id == "service_start_page"
     assert sm.route_for_current_state == MultiPageFormRoutes.JOURNEY_START.value
+
+
+def test_continue_from_your_order_type_british_army_officer_form():
+    sm = RoutingStateMachine()
+    sm.continue_from_your_order_type_british_army_officer_form()
+    assert sm.current_state.id == "your_contact_details_form"
+    assert sm.route_for_current_state == MultiPageFormRoutes.YOUR_CONTACT_DETAILS.value

--- a/test/playwright/end-to-end/to-order-summary-and-back.spec.ts
+++ b/test/playwright/end-to-end/to-order-summary-and-back.spec.ts
@@ -71,10 +71,9 @@ test.describe("End-to-end journey", () => {
         "",
       );
       await continueFromServicePersonDetails(page, robertHughJones);
-      await continueFromHaveYouPreviouslyMadeARequest(
-        page,
-        robertHughJones.hasPreviouslyMadeRequest,
-      );
+      await continueFromHaveYouPreviouslyMadeARequest(page, {
+        label: robertHughJones.hasPreviouslyMadeRequest,
+      });
       await continueFromChooseYourOrderType(
         page,
         robertHughJones.orderSelection,

--- a/test/playwright/lib/constants.ts
+++ b/test/playwright/lib/constants.ts
@@ -31,6 +31,7 @@ export const Paths = {
   WHAT_WAS_THEIR_DATE_OF_BIRTH: `${basePath}/what-was-their-date-of-birth/`,
   YOUR_CONTACT_DETAILS: `${basePath}/your-contact-details/`,
   WHAT_IS_YOUR_ADDRESS: `${basePath}/what-is-your-address/`,
+  YOUR_ORDER_TYPE_BRITISH_ARMY_OFFICERS: `${basePath}/your-order-type-british-army-officers/`,
   YOUR_ORDER_SUMMARY: `${basePath}/your-order-summary/`,
   NOT_A_VALID_LINK: `${basePath}/not-a-valid-second-payment-link/`,
   PAYMENT_LINK_EXPIRED: `${basePath}/second-payment-link-expired/`,

--- a/test/playwright/lib/step-functions.ts
+++ b/test/playwright/lib/step-functions.ts
@@ -154,7 +154,7 @@ export async function continueFromWeAreUnlikelyToHoldThisRecord(
 ) {
   await expect(page).toHaveURL(pathVariant);
   await expect(page.locator("h1")).toHaveText(
-    /We are unlikely to hold this record/,
+    /We are unlikely to hold this record yet/,
   );
   await clickContinueThisRequestForm(page, "button");
 }
@@ -382,9 +382,12 @@ export async function continueFromServicePersonDetails(
 
 export async function continueFromHaveYouPreviouslyMadeARequest(
   page: any,
-  label: any,
-  errorMessage?: any,
-  populatedReferenceNumber?: any,
+  {
+    label = null,
+    errorMessage = null,
+    populatedReferenceNumber = null,
+    nextPath = null,
+  },
 ) {
   await expect(page).toHaveURL(Paths.HAVE_YOU_PREVIOUSLY_MADE_A_REQUEST);
   await expect(page.locator("h1")).toHaveText(
@@ -401,7 +404,7 @@ export async function continueFromHaveYouPreviouslyMadeARequest(
         errorMessage,
       );
     } else {
-      await expect(page).toHaveURL(Paths.CHOOSE_YOUR_ORDER_TYPE);
+      await expect(page).toHaveURL(nextPath || Paths.CHOOSE_YOUR_ORDER_TYPE);
     }
   }
 }
@@ -517,4 +520,13 @@ export async function clickContinueThisRequestForm(page, element) {
 export async function clickBackLink(page, expectedPath) {
   await page.getByRole("link", { name: "Back", exact: true }).click();
   await expect(page).toHaveURL(expectedPath);
+}
+
+export async function continueFromYourOrderTypeBritishArmyOfficers(page) {
+  await expect(page).toHaveURL(Paths.YOUR_ORDER_TYPE_BRITISH_ARMY_OFFICERS);
+  await expect(page.locator("h1")).toHaveText(/Your order type/);
+  await page
+    .getByRole("button", { name: "Request a Full record check" })
+    .click();
+  await expect(page).toHaveURL(Paths.YOUR_CONTACT_DETAILS);
 }

--- a/test/playwright/state-transitions/have-you-previously-made-a-request.spec.ts
+++ b/test/playwright/state-transitions/have-you-previously-made-a-request.spec.ts
@@ -21,12 +21,12 @@ test.describe("have you previously made a request", () => {
     test("without a selection, the user is shown an error message", async ({
       page,
     }) => {
-      await continueFromHaveYouPreviouslyMadeARequest(
-        page,
-        "",
-        /Tell us if you have made a request for this record before/,
-        false,
-      );
+      await continueFromHaveYouPreviouslyMadeARequest(page, {
+        label: "",
+        errorMessage:
+          /Tell us if you have made a request for this record before/,
+        populatedReferenceNumber: false,
+      });
     });
 
     const selectionMappings = [
@@ -34,52 +34,51 @@ test.describe("have you previously made a request", () => {
         description:
           "with 'No' selected the user proceeds to the 'Choose your order type' page",
         label: "No",
-        populateReferenceNumber: false,
+        populatedReferenceNumber: false,
       },
       {
         description:
           "with MoD selected and no reference number provided, there is an error message",
         label: "Yes, to the Ministry of Defence",
-        populateReferenceNumber: false,
+        populatedReferenceNumber: false,
         errorMessage: /Enter the reference number for your previous request/,
       },
       {
         description:
           "with TNA selected and no reference number provided, there is an error message",
         label: "Yes, to The National Archives",
-        populateReferenceNumber: false,
+        populatedReferenceNumber: false,
         errorMessage: /Enter the reference number for your previous request/,
       },
       {
         description:
           "with TNA selected and an excessively long reference number provided, there is an error message",
         label: "Yes, to The National Archives",
-        populateReferenceNumber: "abcdefghijklmnopqrstuvwxyz".repeat(4),
+        populatedReferenceNumber: "abcdefghijklmnopqrstuvwxyz".repeat(4),
         errorMessage: /Reference number must be 64 characters or less/,
       },
       {
         description:
           "with MoD selected and a reference number provided, the user proceeds to the 'Choose your order type' page",
         label: "Yes, to the Ministry of Defence",
-        populateReferenceNumber: "ABC 123",
+        populatedReferenceNumber: "ABC 123",
       },
       {
         description:
           "with TNA selected and a reference number provided, the user proceeds to the 'Choose your order type' page",
         label: "Yes, to The National Archives",
-        populateReferenceNumber: "ABC 123",
+        populatedReferenceNumber: "ABC 123",
       },
     ];
 
     selectionMappings.forEach(
-      ({ description, label, errorMessage, populateReferenceNumber }) => {
+      ({ description, label, errorMessage, populatedReferenceNumber }) => {
         test(description, async ({ page }) => {
-          await continueFromHaveYouPreviouslyMadeARequest(
-            page,
+          await continueFromHaveYouPreviouslyMadeARequest(page, {
             label,
             errorMessage,
-            populateReferenceNumber,
-          );
+            populatedReferenceNumber,
+          });
         });
       },
     );

--- a/test/playwright/state-transitions/your-order-type-british-army-officers.spec.ts
+++ b/test/playwright/state-transitions/your-order-type-british-army-officers.spec.ts
@@ -1,0 +1,83 @@
+import { test } from "@playwright/test";
+import { Paths } from "../lib/constants";
+import {
+  continueFromBeforeYouStart,
+  continueFromHaveYouPreviouslyMadeARequest,
+  continueFromHowWeProcessRequests,
+  continueFromIsServicePersonAlive,
+  continueFromJourneyStart,
+  continueFromProvideAProofOfDeath,
+  continueFromServicePersonDetails,
+  continueFromUploadAProofOfDeath,
+  continueFromWeAreUnlikelyToHoldThisRecord,
+  continueFromWereTheyACommissionedOfficer,
+  continueFromWhatWasTheirDateOfBirth,
+  continueFromWhichMilitaryBranchDidThePersonServeIn,
+  continueFromYouMayWantToCheckAncestry,
+  continueFromYourOrderTypeBritishArmyOfficers,
+} from "../lib/step-functions";
+import { robertHughJones } from "../end-to-end/test-cases/robert-hugh-jones";
+
+test.describe("the 'Request a military service record' form", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto(Paths.JOURNEY_START);
+  });
+
+  test("works as expected", async ({ page }) => {
+    test.setTimeout(120_000); // Increase timeout to 2 minutes for this test because it is end-to-end
+    await continueFromJourneyStart(page);
+    await continueFromHowWeProcessRequests(page);
+    await continueFromBeforeYouStart(page, true);
+    await continueFromYouMayWantToCheckAncestry(page);
+    await continueFromIsServicePersonAlive(
+      page,
+      robertHughJones.isAlive,
+      Paths.WHICH_MILITARY_BRANCH_DID_THE_PERSON_SERVE_IN,
+    );
+    await continueFromWhichMilitaryBranchDidThePersonServeIn(
+      page,
+      robertHughJones.serviceBranch,
+      Paths.WERE_THEY_A_COMMISSIONED_OFFICER,
+    );
+    await continueFromWereTheyACommissionedOfficer(
+      page,
+      "Yes", // Robert Hugh Jones was not a commissioned officer, so we select "Yes" to the question "Were they a commissioned officer?" to reach the "Your order type" page for Commissioned Officers
+      Paths.WE_ARE_UNLIKELY_TO_HOLD_OFFICER_RECORDS__ARMY,
+      "unlikely-to-hold--army-officer-records",
+    );
+    await continueFromWeAreUnlikelyToHoldThisRecord(
+      page,
+      Paths.WE_ARE_UNLIKELY_TO_HOLD_OFFICER_RECORDS__ARMY,
+    );
+    await continueFromWhatWasTheirDateOfBirth(
+      page,
+      robertHughJones.dateOfBirth.day,
+      robertHughJones.dateOfBirth.month,
+      robertHughJones.dateOfBirth.year,
+      Paths.PROVIDE_A_PROOF_OF_DEATH,
+      true,
+      "",
+    );
+    await continueFromProvideAProofOfDeath(
+      page,
+      robertHughJones.hasDeathCertificate,
+      Paths.UPLOAD_A_PROOF_OF_DEATH,
+      "Upload a proof of death",
+    );
+    await continueFromUploadAProofOfDeath(
+      page,
+      ".jpg",
+      1024 * 1024 * 4, //  4MB
+      true,
+      "",
+    );
+    await continueFromServicePersonDetails(page, robertHughJones);
+    await continueFromHaveYouPreviouslyMadeARequest(page, {
+      label: robertHughJones.hasPreviouslyMadeRequest,
+      errorMessage: null,
+      populatedReferenceNumber: null,
+      nextPath: Paths.YOUR_ORDER_TYPE_BRITISH_ARMY_OFFICERS,
+    });
+    await continueFromYourOrderTypeBritishArmyOfficers(page);
+  });
+});


### PR DESCRIPTION
This pull request is quite involved. It includes:

1. Introducing a new template, route, content block etc.
2. Introducing a new state in the state machine (with test)
3. Introducing a new Playwright step function and test - simulating the journey to the new page to ensure it does what's expected.
4. Updating `continueFromHaveYouPreviouslyMadeARequest` signature to accept a configuration object because the list of individual arguments was too long