### PR TITLE
FOI-294: New "Your order type" page for "Other" and "I do not know" service branches

### DIFF
--- a/app/constants.py
+++ b/app/constants.py
@@ -44,6 +44,9 @@ class MultiPageFormRoutes(Enum):
     YOUR_CONTACT_DETAILS = "main.your_contact_details"
     WHAT_IS_YOUR_ADDRESS = "main.what_is_your_address"
     YOUR_ORDER_TYPE_BRITISH_ARMY_OFFICER = "main.your_order_type_british_army_officers"
+    YOUR_ORDER_TYPE_OTHER_AND_DONT_KNOW_OFFICER = (
+        "main.your_order_type_other_and_dont_know_officers"
+    )
     CHOOSE_YOUR_ORDER_TYPE = "main.choose_your_order_type"
     YOUR_ORDER_SUMMARY = "main.your_order_summary"
     SEND_TO_GOV_UK_PAY = "main.send_to_gov_uk_pay"

--- a/app/content/content.yaml
+++ b/app/content/content.yaml
@@ -412,6 +412,37 @@ pages:
               - The search fee is not refundable.
     final_paragraphs:
       - We will send you a digital colour scan of the record by email. You can request a printed copy by post for an extra cost.
+  your_order_type_other_and_dont_know_officers:
+    heading: Your order type
+    paragraphs:
+      - |
+        You are requesting a Commissioned Officer record. These can only be requested with a Full record check, our Standard option is not available.
+      - |
+        As Commissioned Officer records are currently being transferred to us from the Ministry of Defence, we recommend waiting until December 2026 to submit your request. By then, we anticipate most will have been transferred to us.
+    full_record_check:
+      heading: Full record check
+      paragraphs:
+        - |
+          Service records will, in most cases, contain sensitive information and will be closed to the public. However, we can complete a sensitivity check of the record to assess what can be released.
+        - |
+          In some cases, we will not be able to supply the entire record, or large parts of it will be redacted.
+        - |
+          We charge two fees for a Full record check. The first covers the search for the record and a page check. We will then email you a quote for the second payment to copy the parts of the record that can be released, priced per page. Commissioned Officer records can exceed 100 pages.
+      information_list:
+        list_items:
+          - term: What it costs
+            description:
+              - An upfront payment of £48.87, which covers the search (£38.95) and the page check (£9.92).
+              - A second payment of £1.04 per page. For example, 100 pages will cost an additional £104.
+          - term: When you will get the record
+            description:
+              - We aim to confirm if we hold the record within 30 working days. The record will be released once we have received the second payment.
+          - term: Refunds
+            description:
+              - We will refund the page check fee (£9.92) if we do not hold the record.
+              - The search fee is not refundable.
+    final_paragraphs:
+      - We will send you a digital colour scan of the record by email. You can request a printed copy by post for an extra cost.
   choose_your_order_type:
     heading: Choose your order type
     paragraphs:
@@ -709,4 +740,6 @@ forms:
     sorry_you_will_have_to_start_again:
       call_to_action: Start again
     your_order_type_british_army_officers:
+      call_to_action: Request a Full record check
+    your_order_type_other_and_dont_know_officers:
       call_to_action: Request a Full record check

--- a/app/lib/state_machine/state_machine.py
+++ b/app/lib/state_machine/state_machine.py
@@ -161,6 +161,10 @@ class RoutingStateMachine(StateMachine):
         enter="entering_your_order_type_british_army_officer_form", final=True
     )
 
+    your_order_type_other_and_dont_know_officer_form = State(
+        enter="entering_your_order_type_other_and_dont_know_officer_form", final=True
+    )
+
     choose_your_order_type_form = State(
         enter="entering_choose_your_order_type_form", final=True
     )
@@ -308,16 +312,31 @@ class RoutingStateMachine(StateMachine):
         have_you_previously_made_a_request_form
     )
 
-    continue_from_have_you_previously_made_a_request_form = initial.to(
-        your_order_type_british_army_officer_form,
-        cond="was_officer and service_branch_is_army",
-    ) | initial.to(choose_your_order_type_form)
+    continue_from_have_you_previously_made_a_request_form = (
+        initial.to(
+            your_order_type_british_army_officer_form,
+            cond="was_officer and service_branch_is_army",
+        )
+        | initial.to(
+            your_order_type_other_and_dont_know_officer_form,
+            cond="was_officer and service_branch_is_other",
+        )
+        | initial.to(
+            your_order_type_other_and_dont_know_officer_form,
+            cond="was_officer and service_branch_is_unknown",
+        )
+        | initial.to(choose_your_order_type_form)
+    )
 
     continue_from_your_contact_details_form = initial.to(
         what_is_your_address_form, cond="does_not_have_email"
     ) | initial.to(your_order_summary_form)
 
     continue_from_what_is_your_address_form = initial.to(your_order_summary_form)
+
+    continue_from_your_order_type_other_and_dont_know_officer_form = initial.to(
+        your_contact_details_form
+    )
 
     continue_from_your_order_type_british_army_officer_form = initial.to(
         your_contact_details_form
@@ -466,6 +485,11 @@ class RoutingStateMachine(StateMachine):
     def entering_your_order_type_british_army_officer_form(self):
         self.route_for_current_state = (
             MultiPageFormRoutes.YOUR_ORDER_TYPE_BRITISH_ARMY_OFFICER.value
+        )
+
+    def entering_your_order_type_other_and_dont_know_officer_form(self):
+        self.route_for_current_state = (
+            MultiPageFormRoutes.YOUR_ORDER_TYPE_OTHER_AND_DONT_KNOW_OFFICER.value
         )
 
     def entering_choose_your_order_type_form(self):

--- a/app/main/forms/your_order_type_other_and_dont_know_officers.py
+++ b/app/main/forms/your_order_type_other_and_dont_know_officers.py
@@ -1,0 +1,24 @@
+from app.lib.content import get_field_content, load_content
+from flask_wtf import FlaskForm
+from tna_frontend_jinja.wtforms import (
+    TnaSubmitWidget,
+)
+from wtforms import (
+    HiddenField,
+    SubmitField,
+)
+
+
+class YourOrderTypeOtherAndDontKnowOfficers(FlaskForm):
+    content = load_content()
+
+    processing_option = HiddenField()
+
+    submit = SubmitField(
+        get_field_content(
+            content,
+            "your_order_type_other_and_dont_know_officers",
+            "call_to_action",
+        ),
+        widget=TnaSubmitWidget(),
+    )

--- a/app/main/routes/routes.py
+++ b/app/main/routes/routes.py
@@ -58,6 +58,10 @@ from app.main.forms.your_order_type_british_army_officers import (
 
 from flask import redirect, render_template, request, session, url_for
 
+from app.main.forms.your_order_type_other_and_dont_know_officers import (
+    YourOrderTypeOtherAndDontKnowOfficers,
+)
+
 
 @bp.route("/", methods=["GET", "POST"])
 @with_state_machine
@@ -646,6 +650,23 @@ def your_order_type_british_army_officers(form, state_machine):
 
     return render_template(
         "main/your-order-type-british-army-officers.html",
+        content=load_content(),
+        form=form,
+    )
+
+
+@bp.route("/your-order-type-other-and-dont-know-officers/", methods=["GET", "POST"])
+@with_form_prefilled_from_session(YourOrderTypeOtherAndDontKnowOfficers)
+@with_state_machine
+def your_order_type_other_and_dont_know_officers(form, state_machine):
+    if form.validate_on_submit():
+        save_submitted_form_fields_to_session(form)
+        state_machine.continue_from_your_order_type_other_and_dont_know_officer_form(
+            form
+        )
+        return redirect(url_for(state_machine.route_for_current_state))
+    return render_template(
+        "main/your-order-type-other-and-dont-know-officers.html",
         content=load_content(),
         form=form,
     )

--- a/app/templates/main/your-order-type-other-and-dont-know-officers.html
+++ b/app/templates/main/your-order-type-other-and-dont-know-officers.html
@@ -1,0 +1,43 @@
+{% extends "base.html" %}
+
+{%- set pageTitle = content.pages.your_order_type_other_and_dont_know_officers.heading | prepare_page_title -%}
+
+{% block beforeContent %}
+  {{ backLink(url_for('main.have_you_previously_made_a_request')) }}
+{% endblock beforeContent %}
+
+{% block content %}
+  <div class="tna-section tna-!--padding-top-s">
+    <div class="tna-container">
+      <div
+        class="tna-column tna-column--width-2-3 tna-column--width-5-6-medium tna-column--full-small tna-column--full-tiny">
+        <h1
+          class="tna-heading-xl tna-!--margin-top-m">{{ content.pages.your_order_type_other_and_dont_know_officers.heading }}</h1>
+        {% for paragraph in content.pages.your_order_type_other_and_dont_know_officers.paragraphs %}
+          <p>{{ paragraph }}</p>
+        {% endfor %}
+
+        <h2
+          class="tna-heading-l">{{ content.pages.your_order_type_other_and_dont_know_officers.full_record_check.heading }}</h2>
+        {% for paragraph in content.pages.your_order_type_other_and_dont_know_officers.full_record_check.paragraphs %}
+          <p>{{ paragraph }}</p>
+        {% endfor %}
+        {% if content.pages.your_order_type_other_and_dont_know_officers.full_record_check.information_list.list_items %}
+          {{ descriptionList(content.pages.your_order_type_other_and_dont_know_officers.full_record_check.information_list.list_items) }}
+        {% endif %}
+        {% for paragraph in content.pages.your_order_type_other_and_dont_know_officers.final_paragraphs %}
+          <p>{{ paragraph }}</p>
+        {% endfor %}
+        <div class="tna-!--margin-top-m">
+          <form action="{{ url_for('main.your_order_type_other_and_dont_know_officers') }}" method="post" novalidate>
+            {{ form.csrf_token }}
+            {{ form.processing_option(value='full', id='processing_option_full_record_check') }}
+            <div class="tna-button-group">
+              {{ form.submit(params={'classes': 'tna-button--accent'}) }}
+            </div>
+          </form>
+        </div>
+      </div>
+    </div>
+  </div>
+{% endblock content %}

--- a/test/main/test_state_machine.py
+++ b/test/main/test_state_machine.py
@@ -435,11 +435,56 @@ def test_continue_from_service_person_details():
     )
 
 
-def test_continue_from_have_you_previously_made_a_request():
+@pytest.mark.parametrize(
+    "service_branch,was_officer,expected_state,expected_route",
+    [
+        (
+            "BRITISH_ARMY",
+            "yes",
+            "your_order_type_british_army_officer_form",
+            MultiPageFormRoutes.YOUR_ORDER_TYPE_BRITISH_ARMY_OFFICER.value,
+        ),
+        (
+            "BRITISH_ARMY",
+            "no",
+            "choose_your_order_type_form",
+            MultiPageFormRoutes.CHOOSE_YOUR_ORDER_TYPE.value,
+        ),
+        (
+            "OTHER",
+            "yes",
+            "your_order_type_other_and_dont_know_officer_form",
+            MultiPageFormRoutes.YOUR_ORDER_TYPE_OTHER_AND_DONT_KNOW_OFFICER.value,
+        ),
+        (
+            "OTHER",
+            "no",
+            "choose_your_order_type_form",
+            MultiPageFormRoutes.CHOOSE_YOUR_ORDER_TYPE.value,
+        ),
+        (
+            "UNKNOWN",
+            "yes",
+            "your_order_type_other_and_dont_know_officer_form",
+            MultiPageFormRoutes.YOUR_ORDER_TYPE_OTHER_AND_DONT_KNOW_OFFICER.value,
+        ),
+        (
+            "UNKNOWN",
+            "no",
+            "choose_your_order_type_form",
+            MultiPageFormRoutes.CHOOSE_YOUR_ORDER_TYPE.value,
+        ),
+    ],
+)
+def test_continue_from_have_you_previously_made_a_request_routes_by_condition(
+    service_branch, was_officer, expected_state, expected_route
+):
     sm = RoutingStateMachine()
 
     sm.continue_from_have_you_previously_made_a_request_form(
         form=make_form(
+            service_branch=service_branch,
+            were_they_a_commissioned_officer=was_officer,
             forenames=None,
             last_name=None,
             place_of_birth=None,
@@ -448,10 +493,12 @@ def test_continue_from_have_you_previously_made_a_request():
             service_number=None,
             regiment=None,
             additional_information=None,
-            were_they_a_commissioned_officer=None,
             submit=None,
         )
     )
+
+    assert sm.current_state.id == expected_state
+    assert sm.route_for_current_state == expected_route
 
 
 @pytest.mark.parametrize(

--- a/test/playwright/end-to-end/test-cases/your-order-type-variants/army-officer.ts
+++ b/test/playwright/end-to-end/test-cases/your-order-type-variants/army-officer.ts
@@ -1,0 +1,35 @@
+export const armyOfficer = {
+  firstName: "Jeremiah",
+  lastName: "Thompson",
+  otherLastNames: "Miller",
+  serviceNumber: "T2156487",
+  placeOfBirth: "Manchester",
+  dateOfBirth: {
+    day: "23",
+    month: "03",
+    year: "1918",
+  },
+  serviceBranch: "British Army",
+  wasOfficer: "Yes",
+  isAlive: "No",
+  dateOfDeath: {
+    day: "12",
+    month: "07",
+    year: "2003",
+  },
+  hasDeathCertificate: "Yes",
+  hasPreviouslyMadeRequest: "No",
+  orderSelection: "Choose standard",
+  didTheyDieInService: "No",
+  regimentOrSquadron: "Royal Artillery",
+  additionalInformation: `
+    Jeremiah Thompson served in the Royal Artillery during World War II.
+    He served in North Africa, Sicily, Italy, France and Germany.
+    He was promoted to Sergeant in 1942 and remained in service until 1946.
+  `,
+  personMakingRequest: {
+    firstName: "Margaret",
+    lastName: "Thompson",
+    emailAddress: "margaret.thompson@example.com",
+  },
+};

--- a/test/playwright/end-to-end/test-cases/your-order-type-variants/other-officer.ts
+++ b/test/playwright/end-to-end/test-cases/your-order-type-variants/other-officer.ts
@@ -1,0 +1,35 @@
+export const otherOfficer = {
+  firstName: "Alfred",
+  lastName: "Bennett",
+  otherLastNames: "Carter",
+  serviceNumber: "B3075194",
+  placeOfBirth: "Liverpool",
+  dateOfBirth: {
+    day: "09",
+    month: "11",
+    year: "1917",
+  },
+  serviceBranch: "Other",
+  wasOfficer: "Yes",
+  isAlive: "No",
+  dateOfDeath: {
+    day: "18",
+    month: "04",
+    year: "2001",
+  },
+  hasDeathCertificate: "Yes",
+  hasPreviouslyMadeRequest: "No",
+  orderSelection: "Choose Full record check",
+  didTheyDieInService: "No",
+  regimentOrSquadron: "Royal Engineers",
+  additionalInformation: `
+    Alfred Bennett served in the Royal Engineers during World War II.
+    He served in Egypt, Italy, Belgium, the Netherlands and Germany.
+    He was injured in 1944 and later returned to duty before leaving service in 1946.
+  `,
+  personMakingRequest: {
+    firstName: "Elaine",
+    lastName: "Bennett",
+    emailAddress: "elaine.bennett@example.com",
+  },
+};

--- a/test/playwright/end-to-end/test-cases/your-order-type-variants/unknown-officer.ts
+++ b/test/playwright/end-to-end/test-cases/your-order-type-variants/unknown-officer.ts
@@ -1,0 +1,35 @@
+export const unknownOfficer = {
+  firstName: "Harold",
+  lastName: "Sinclair",
+  otherLastNames: "Davies",
+  serviceNumber: "S4821736",
+  placeOfBirth: "Bristol",
+  dateOfBirth: {
+    day: "27",
+    month: "02",
+    year: "1916",
+  },
+  serviceBranch: "I do not know",
+  wasOfficer: "Yes",
+  isAlive: "No",
+  dateOfDeath: {
+    day: "05",
+    month: "10",
+    year: "1999",
+  },
+  hasDeathCertificate: "Yes",
+  hasPreviouslyMadeRequest: "No",
+  orderSelection: "Choose standard",
+  didTheyDieInService: "No",
+  regimentOrSquadron: "Royal Signals",
+  additionalInformation: `
+    Harold Sinclair served with the Royal Signals during World War II.
+    He served in Malta, Tunisia, Sicily, Italy and Austria.
+    He was commissioned in 1943 and remained in service until 1947.
+  `,
+  personMakingRequest: {
+    firstName: "Janet",
+    lastName: "Sinclair",
+    emailAddress: "janet.sinclair@example.com",
+  },
+};

--- a/test/playwright/lib/constants.ts
+++ b/test/playwright/lib/constants.ts
@@ -32,6 +32,7 @@ export const Paths = {
   YOUR_CONTACT_DETAILS: `${basePath}/your-contact-details/`,
   WHAT_IS_YOUR_ADDRESS: `${basePath}/what-is-your-address/`,
   YOUR_ORDER_TYPE_BRITISH_ARMY_OFFICERS: `${basePath}/your-order-type-british-army-officers/`,
+  YOUR_ORDER_TYPE_OTHER_AND_DONT_KNOW_OFFICERS: `${basePath}/your-order-type-other-and-dont-know-officers/`,
   YOUR_ORDER_SUMMARY: `${basePath}/your-order-summary/`,
   NOT_A_VALID_LINK: `${basePath}/not-a-valid-second-payment-link/`,
   PAYMENT_LINK_EXPIRED: `${basePath}/second-payment-link-expired/`,

--- a/test/playwright/lib/step-functions.ts
+++ b/test/playwright/lib/step-functions.ts
@@ -530,3 +530,14 @@ export async function continueFromYourOrderTypeBritishArmyOfficers(page) {
     .click();
   await expect(page).toHaveURL(Paths.YOUR_CONTACT_DETAILS);
 }
+
+export async function continueFromYourOrderTypeOtherAndDontKnowOfficers(page) {
+  await expect(page).toHaveURL(
+    Paths.YOUR_ORDER_TYPE_OTHER_AND_DONT_KNOW_OFFICERS,
+  );
+  await expect(page.locator("h1")).toHaveText(/Your order type/);
+  await page
+    .getByRole("button", { name: "Request a Full record check" })
+    .click();
+  await expect(page).toHaveURL(Paths.YOUR_CONTACT_DETAILS);
+}

--- a/test/playwright/state-transitions/your-order-type-other-and-dont-know.spec.ts
+++ b/test/playwright/state-transitions/your-order-type-other-and-dont-know.spec.ts
@@ -14,70 +14,92 @@ import {
   continueFromWhatWasTheirDateOfBirth,
   continueFromWhichMilitaryBranchDidThePersonServeIn,
   continueFromYouMayWantToCheckAncestry,
-  continueFromYourOrderTypeBritishArmyOfficers,
+  continueFromYourOrderTypeOtherAndDontKnowOfficers,
 } from "../lib/step-functions";
-import { armyOfficer } from "../end-to-end/test-cases/your-order-type-variants/army-officer";
+import { otherOfficer } from "../end-to-end/test-cases/your-order-type-variants/other-officer";
+import { unknownOfficer } from "../end-to-end/test-cases/your-order-type-variants/unknown-officer";
 
-test.describe("the 'Your order type page for British Army officers' form", () => {
+test.describe("the 'Your order type for officers where service branch is 'other' or unknown form", () => {
+  const scenarios = [{ person: otherOfficer }, { person: unknownOfficer }];
+
   test.beforeEach(async ({ page }) => {
     await page.goto(Paths.JOURNEY_START);
   });
 
-  test("works as expected", async ({ page }) => {
-    test.setTimeout(120_000); // Increase timeout to 2 minutes for this test because it is end-to-end
+  async function runFromStartPageToYourOrderTypePage(page, person) {
+    test.setTimeout(120_000); // End-to-end path
+
     await continueFromJourneyStart(page);
     await continueFromHowWeProcessRequests(page);
     await continueFromBeforeYouStart(page, true);
     await continueFromYouMayWantToCheckAncestry(page);
+
     await continueFromIsServicePersonAlive(
       page,
-      armyOfficer.isAlive,
+      person.isAlive,
       Paths.WHICH_MILITARY_BRANCH_DID_THE_PERSON_SERVE_IN,
     );
+
     await continueFromWhichMilitaryBranchDidThePersonServeIn(
       page,
-      armyOfficer.serviceBranch,
+      person.serviceBranch,
       Paths.WERE_THEY_A_COMMISSIONED_OFFICER,
     );
+
     await continueFromWereTheyACommissionedOfficer(
       page,
-      armyOfficer.wasOfficer,
-      Paths.WE_ARE_UNLIKELY_TO_HOLD_OFFICER_RECORDS__ARMY,
-      "unlikely-to-hold--army-officer-records",
+      person.wasOfficer,
+      Paths.WE_ARE_UNLIKELY_TO_HOLD_OFFICER_RECORDS__GENERIC,
+      "we-are-unlikely-to-hold-this-record--generic",
     );
+
     await continueFromWeAreUnlikelyToHoldThisRecord(
       page,
-      Paths.WE_ARE_UNLIKELY_TO_HOLD_OFFICER_RECORDS__ARMY,
+      Paths.WE_ARE_UNLIKELY_TO_HOLD_OFFICER_RECORDS__GENERIC,
     );
+
     await continueFromWhatWasTheirDateOfBirth(
       page,
-      armyOfficer.dateOfBirth.day,
-      armyOfficer.dateOfBirth.month,
-      armyOfficer.dateOfBirth.year,
+      person.dateOfBirth.day,
+      person.dateOfBirth.month,
+      person.dateOfBirth.year,
       Paths.PROVIDE_A_PROOF_OF_DEATH,
       true,
       "",
     );
+
     await continueFromProvideAProofOfDeath(
       page,
-      armyOfficer.hasDeathCertificate,
+      person.hasDeathCertificate,
       Paths.UPLOAD_A_PROOF_OF_DEATH,
       "Upload a proof of death",
     );
+
     await continueFromUploadAProofOfDeath(
       page,
       ".jpg",
-      1024 * 1024 * 4, //  4MB
+      1024 * 1024 * 4,
       true,
       "",
     );
-    await continueFromServicePersonDetails(page, armyOfficer);
+
+    await continueFromServicePersonDetails(page, person);
+
     await continueFromHaveYouPreviouslyMadeARequest(page, {
-      label: armyOfficer.hasPreviouslyMadeRequest,
+      label: person.hasPreviouslyMadeRequest,
       errorMessage: null,
       populatedReferenceNumber: null,
-      nextPath: Paths.YOUR_ORDER_TYPE_BRITISH_ARMY_OFFICERS,
+      nextPath: Paths.YOUR_ORDER_TYPE_OTHER_AND_DONT_KNOW_OFFICERS,
     });
-    await continueFromYourOrderTypeBritishArmyOfficers(page);
+
+    await continueFromYourOrderTypeOtherAndDontKnowOfficers(page);
+  }
+
+  scenarios.forEach(({ person }) => {
+    test(`works as expected when service branch is '${person.serviceBranch}'`, async ({
+      page,
+    }) => {
+      await runFromStartPageToYourOrderTypePage(page, person);
+    });
   });
 });


### PR DESCRIPTION
This new "Your order type" page is presented when the service branch is either "Other"or "I do not know".
    
The  _technical_ changes support a new flow for users requesting records for Commissioned Officers when the service branch is "Other" or "I do not know", while retaining existing flows for other combinations. This has meant the introduction of: 

- [x] a new dedicated page and state for these cases (maintaining our 1:1 mapping between routes, templates and states)
- [x] updates to the state machine logic and tests
- [x] new content and dedicated end-to-end tests to support this user journey. 

The key user experience change is that users selecting "Other" or "I do not know" as the service branch and "Yes" for officer status are - much later in their journey - routed to a form that explains the only option is "Full record check" (rather than the existing page that presents two options). 

The most important changes are:

1. New flow for 'Other' and 'Unknown' Commissioned Officers
1. New content and form
1. Testing and validation
1. Extended the state machine tests to cover the new routing logic for different combinations of service branch and officer status
1. Added new Playwright end-to-end test data and step functions for "Other" and "Unknown" officer cases, ensuring the new flow is covered in automated browser tests

> [!IMPORTANT] 
> RAMSA is a complex service that needs to support a wide range of user journeys. The state machine approach has helped (a lot) with this - but it can still be quite challenging to get your head round. If you think it would be helpful for me to talk you through the service - or any of the artifacts we've produced - just let me know. 