### PR TITLE
FOI-290: New officer journey

### DIFF
--- a/app/constants.py
+++ b/app/constants.py
@@ -43,6 +43,7 @@ class MultiPageFormRoutes(Enum):
     HAVE_YOU_PREVIOUSLY_MADE_A_REQUEST = "main.have_you_previously_made_a_request"
     YOUR_CONTACT_DETAILS = "main.your_contact_details"
     WHAT_IS_YOUR_ADDRESS = "main.what_is_your_address"
+    YOUR_ORDER_TYPE_BRITISH_ARMY_OFFICER = "main.your_order_type_british_army_officers"
     CHOOSE_YOUR_ORDER_TYPE = "main.choose_your_order_type"
     YOUR_ORDER_SUMMARY = "main.your_order_summary"
     SEND_TO_GOV_UK_PAY = "main.send_to_gov_uk_pay"

--- a/app/constants.py
+++ b/app/constants.py
@@ -44,6 +44,9 @@ class MultiPageFormRoutes(Enum):
     YOUR_CONTACT_DETAILS = "main.your_contact_details"
     WHAT_IS_YOUR_ADDRESS = "main.what_is_your_address"
     YOUR_ORDER_TYPE_BRITISH_ARMY_OFFICER = "main.your_order_type_british_army_officers"
+    YOUR_ORDER_TYPE_OTHER_AND_DONT_KNOW_OFFICER = (
+        "main.your_order_type_other_and_dont_know_officers"
+    )
     CHOOSE_YOUR_ORDER_TYPE = "main.choose_your_order_type"
     YOUR_ORDER_SUMMARY = "main.your_order_summary"
     SEND_TO_GOV_UK_PAY = "main.send_to_gov_uk_pay"

--- a/app/content/content.yaml
+++ b/app/content/content.yaml
@@ -241,6 +241,9 @@ pages:
         Commissioned Officer records are currently being transferred to us. We may not hold the record you are looking for yet.
       - |
         If you have not done so already, we recommend you check with the Ministry of Defence first.
+      - |
+        Unless they served in the Royal Air Force, Commissioned Officer records can only be requested from us using a Full record check, 
+        our Standard option is not available yet.
     call_to_action: Request from the Ministry of Defence
   we_are_unlikely_to_hold_officer_records__raf:
     heading: We are unlikely to hold this record yet
@@ -264,6 +267,8 @@ pages:
         British Army Commissioned Officer records are currently being transferred to us. We may not hold the record you are looking for yet.
       - |
         We anticipate holding most Army Commissioned Officer records by December 2026.
+      - |
+        British Army Commissioned Officer records can only be requested from us using a Full record check, our Standard option is not available yet.
       - |
         We recommend you check with the Ministry of Defence first, unless the record is contained in list the below:
     list:

--- a/app/content/content.yaml
+++ b/app/content/content.yaml
@@ -28,7 +28,7 @@ pages:
             - |
               Standard provides a subset of documents from the record. This may include details
               provided when the service person enlisted, records of service and testimonials.
-            - Standard is not available for Commissioned Officer record requests.
+            - Standard is not available for British Army Commissioned Officer record requests yet.
         - title: Full record check
           paragraphs:
             - |

--- a/app/content/content.yaml
+++ b/app/content/content.yaml
@@ -96,7 +96,7 @@ pages:
       before_first_list:
         paragraphs:
           - |
-            If the person whose record you are looking for was born after 1 January [FIRST_BIRTH_YEAR_FOR_CLOSED_RECORDS] 
+            If the person whose record you are looking for was born on or after 1 January [FIRST_BIRTH_YEAR_FOR_CLOSED_RECORDS] 
             and is deceased, we require a digital copy of a proof of death. This is to protect 
             any personal data in the record that might relate to a living person.
           - "You will need to submit one of the following forms of evidence:"
@@ -324,7 +324,7 @@ pages:
     heading: Provide a proof of death
     paragraphs:
       - |
-        As you are requesting a record for someone born after 1 January [FIRST_BIRTH_YEAR_FOR_CLOSED_RECORDS], 
+        As you are requesting a record for someone born on or after 1 January [FIRST_BIRTH_YEAR_FOR_CLOSED_RECORDS], 
         you will need to provide a digital copy of a proof of death.
       - >
         You will need to submit one of the following forms of evidence:

--- a/app/content/content.yaml
+++ b/app/content/content.yaml
@@ -412,6 +412,37 @@ pages:
               - The search fee is not refundable.
     final_paragraphs:
       - We will send you a digital colour scan of the record by email. You can request a printed copy by post for an extra cost.
+  your_order_type_other_and_dont_know_officers:
+    heading: Your order type
+    paragraphs:
+      - |
+        You are requesting a Commissioned Officer record. These can only be requested with a Full record check, our Standard option is not available.
+      - |
+        As Commissioned Officer records are currently being transferred to us from the Ministry of Defence, we recommend waiting until December 2026 to submit your request. By then, we anticipate most will have been transferred to us.
+    full_record_check:
+      heading: Full record check
+      paragraphs:
+        - |
+          Service records will, in most cases, contain sensitive information and will be closed to the public. However, we can complete a sensitivity check of the record to assess what can be released.
+        - |
+          In some cases, we will not be able to supply the entire record, or large parts of it will be redacted.
+        - |
+          We charge two fees for a Full record check. The first covers the search for the record and a page check. We will then email you a quote for the second payment to copy the parts of the record that can be released, priced per page. Commissioned Officer records can exceed 100 pages.
+      information_list:
+        list_items:
+          - term: What it costs
+            description:
+              - An upfront payment of £48.87, which covers the search (£38.95) and the page check (£9.92).
+              - A second payment of £1.04 per page. For example, 100 pages will cost an additional £104.
+          - term: When you will get the record
+            description:
+              - We aim to confirm if we hold the record within 30 working days. The record will be released once we have received the second payment.
+          - term: Refunds
+            description:
+              - We will refund the page check fee (£9.92) if we do not hold the record.
+              - The search fee is not refundable.
+    final_paragraphs:
+      - We will send you a digital colour scan of the record by email. You can request a printed copy by post for an extra cost.
   choose_your_order_type:
     heading: Choose your order type
     paragraphs:
@@ -709,4 +740,6 @@ forms:
     sorry_you_will_have_to_start_again:
       call_to_action: Start again
     your_order_type_british_army_officers:
+      call_to_action: Request a Full record check
+    your_order_type_other_and_dont_know_officers:
       call_to_action: Request a Full record check

--- a/app/content/content.yaml
+++ b/app/content/content.yaml
@@ -381,6 +381,37 @@ pages:
     heading: What is your address?
     paragraphs:
       - You have not provided an email address. Please provide a postal address so we can contact you about your request and, if we have the record, send it to you. There will be an extra fee for printed copies.
+  your_order_type_army_officer:
+    heading: Your order type
+    paragraphs:
+      - |
+        You are requesting a British Army Commissioned Officer record. These can only be requested with a Full record check, our Standard option is not available.
+      - |
+        As British Army Commissioned Officer records are currently being transferred to us from the Ministry of Defence, we recommend waiting until December 2026 to submit your request. By then, we anticipate most will have been transferred to us.
+    full_record_check:
+      heading: Full record check
+      paragraphs:
+        - |
+          Service records will, in most cases, contain sensitive information and will be closed to the public. However, we can complete a sensitivity check of the record to assess what can be released.
+        - |
+          In some cases, we will not be able to supply the entire record, or large parts of it will be redacted.
+        - |
+          We charge two fees for a Full record check. The first covers the search for the record and a page check. We will then email you a quote for the second payment to copy the parts of the record that can be released, priced per page. Commissioned Officer records can exceed 100 pages.
+      information_list:
+        list_items:
+          - term: What it costs
+            description:
+              - An upfront payment of £48.87, which covers the search (£38.95) and the page check (£9.92).
+              - A second payment of £1.04 per page. For example, 100 pages will cost an additional £104.
+          - term: When you will get the record
+            description:
+              - We aim to confirm if we hold the record within 30 working days. The record will be released once we have received the second payment.
+          - term: Refunds
+            description:
+              - We will refund the page check fee (£9.92) if we do not hold the record.
+              - The search fee is not refundable.
+    final_paragraphs:
+      - We will send you a digital colour scan of the record by email. You can request a printed copy by post for an extra cost.
   choose_your_order_type:
     heading: Choose your order type
     paragraphs:
@@ -677,3 +708,5 @@ forms:
       call_to_action: Go back to try the payment again
     sorry_you_will_have_to_start_again:
       call_to_action: Start again
+    your_order_type_british_army_officers:
+      call_to_action: Request a Full record check

--- a/app/content/content.yaml
+++ b/app/content/content.yaml
@@ -28,7 +28,7 @@ pages:
             - |
               Standard provides a subset of documents from the record. This may include details
               provided when the service person enlisted, records of service and testimonials.
-            - Standard is not available for British Army Commissioned Officer record requests yet.
+            - Standard is not available for British Army Commissioned Officer record requests.
         - title: Full record check
           paragraphs:
             - |
@@ -243,7 +243,7 @@ pages:
         If you have not done so already, we recommend you check with the Ministry of Defence first.
       - |
         Unless they served in the Royal Air Force, Commissioned Officer records can only be requested from us using a Full record check, 
-        our Standard option is not available yet.
+        our Standard option is not available.
     call_to_action: Request from the Ministry of Defence
   we_are_unlikely_to_hold_officer_records__raf:
     heading: We are unlikely to hold this record yet
@@ -263,12 +263,9 @@ pages:
   we_are_unlikely_to_hold_officer_records__army:
     heading: We are unlikely to hold this record yet
     paragraphs:
-      - |
-        British Army Commissioned Officer records are currently being transferred to us. We may not hold the record you are looking for yet.
-      - |
-        We anticipate holding most Army Commissioned Officer records by December 2026.
-      - |
-        British Army Commissioned Officer records can only be requested from us using a Full record check, our Standard option is not available yet.
+      - British Army Commissioned Officer records are currently being transferred to us. We may not hold the record you are looking for yet.
+      - We anticipate holding most Army Commissioned Officer records by December 2026.
+      - These records can only be requested from us using a Full record check, our Standard option is not available.
       - |
         We recommend you check with the Ministry of Defence first, unless the record is contained in list the below:
     list:

--- a/app/lib/derive_if_change_order_is_available.py
+++ b/app/lib/derive_if_change_order_is_available.py
@@ -1,0 +1,44 @@
+"""
+Module for deriving if a user can change their order type.
+
+A user can change their order if:
+1. The service person was NOT an officer, OR
+2. The service person was an officer AND the service branch is RAF
+"""
+
+from typing import Optional
+
+
+def derive_if_change_order_is_available(form_data: Optional[dict]) -> bool:
+    """
+    Determine if a user can change their order type based on form data.
+
+    Args:
+        form_data: Dictionary containing form submission data with keys:
+                  - were_they_a_commissioned_officer: "yes", "no", or "unknown"
+                  - service_branch: Service branch identifier (e.g., "ROYAL_AIR_FORCE")
+
+    Returns:
+        bool: True if the user can change their order, False otherwise.
+              Returns True if:
+              - Service person was not an officer (was "no"), OR
+              - Service person was an officer ("yes") AND service branch is "ROYAL_AIR_FORCE"
+
+              Returns False in all other cases.
+    """
+    if form_data is None:
+        return False
+
+    officer_status = form_data.get("were_they_a_commissioned_officer")
+    service_branch = form_data.get("service_branch")
+
+    # If service person was not an officer, return True
+    if officer_status == "no":
+        return True
+
+    # If service person was an officer AND service branch is RAF, return True
+    if officer_status == "yes" and service_branch == "ROYAL_AIR_FORCE":
+        return True
+
+    # All other cases
+    return False

--- a/app/lib/derive_if_change_order_is_available.py
+++ b/app/lib/derive_if_change_order_is_available.py
@@ -22,6 +22,7 @@ def derive_if_change_order_is_available(form_data: Optional[dict]) -> bool:
         bool: True if the user can change their order, False otherwise.
               Returns True if:
               - Service person was not an officer (was "no"), OR
+              - Service person may have been an officer (was "unknown"), OR
               - Service person was an officer ("yes") AND service branch is "ROYAL_AIR_FORCE"
 
               Returns False in all other cases.
@@ -34,6 +35,10 @@ def derive_if_change_order_is_available(form_data: Optional[dict]) -> bool:
 
     # If service person was not an officer, return True
     if officer_status == "no":
+        return True
+
+    # If officer status is unknown, return True
+    if officer_status == "unknown":
         return True
 
     # If service person was an officer AND service branch is RAF, return True

--- a/app/lib/state_machine/state_machine.py
+++ b/app/lib/state_machine/state_machine.py
@@ -158,6 +158,10 @@ class RoutingStateMachine(StateMachine):
         enter="entering_what_is_your_address_form", final=True
     )
 
+    your_order_type_british_army_officer_form = State(
+        enter="entering_your_order_type_british_army_officer_form", final=True
+    )
+
     choose_your_order_type_form = State(
         enter="entering_choose_your_order_type_form", final=True
     )
@@ -306,14 +310,19 @@ class RoutingStateMachine(StateMachine):
     )
 
     continue_from_have_you_previously_made_a_request_form = initial.to(
-        choose_your_order_type_form
-    )
+        your_order_type_british_army_officer_form,
+        cond="was_officer and service_branch_is_army",
+    ) | initial.to(choose_your_order_type_form)
 
     continue_from_your_contact_details_form = initial.to(
         what_is_your_address_form, cond="does_not_have_email"
     ) | initial.to(your_order_summary_form)
 
     continue_from_what_is_your_address_form = initial.to(your_order_summary_form)
+
+    continue_from_your_order_type_british_army_officer_form = initial.to(
+        your_contact_details_form
+    )
 
     continue_from_choose_your_order_type_form = initial.to(your_contact_details_form)
 
@@ -452,6 +461,11 @@ class RoutingStateMachine(StateMachine):
 
     def entering_what_is_your_address_form(self):
         self.route_for_current_state = MultiPageFormRoutes.WHAT_IS_YOUR_ADDRESS.value
+
+    def entering_your_order_type_british_army_officer_form(self):
+        self.route_for_current_state = (
+            MultiPageFormRoutes.YOUR_ORDER_TYPE_BRITISH_ARMY_OFFICER.value
+        )
 
     def entering_choose_your_order_type_form(self):
         self.route_for_current_state = MultiPageFormRoutes.CHOOSE_YOUR_ORDER_TYPE.value

--- a/app/lib/state_machine/state_machine.py
+++ b/app/lib/state_machine/state_machine.py
@@ -162,6 +162,10 @@ class RoutingStateMachine(StateMachine):
         enter="entering_your_order_type_british_army_officer_form", final=True
     )
 
+    your_order_type_other_and_dont_know_officer_form = State(
+        enter="entering_your_order_type_other_and_dont_know_officer_form", final=True
+    )
+
     choose_your_order_type_form = State(
         enter="entering_choose_your_order_type_form", final=True
     )
@@ -309,16 +313,31 @@ class RoutingStateMachine(StateMachine):
         have_you_previously_made_a_request_form
     )
 
-    continue_from_have_you_previously_made_a_request_form = initial.to(
-        your_order_type_british_army_officer_form,
-        cond="was_officer and service_branch_is_army",
-    ) | initial.to(choose_your_order_type_form)
+    continue_from_have_you_previously_made_a_request_form = (
+        initial.to(
+            your_order_type_british_army_officer_form,
+            cond="was_officer and service_branch_is_army",
+        )
+        | initial.to(
+            your_order_type_other_and_dont_know_officer_form,
+            cond="was_officer and service_branch_is_other",
+        )
+        | initial.to(
+            your_order_type_other_and_dont_know_officer_form,
+            cond="was_officer and service_branch_is_unknown",
+        )
+        | initial.to(choose_your_order_type_form)
+    )
 
     continue_from_your_contact_details_form = initial.to(
         what_is_your_address_form, cond="does_not_have_email"
     ) | initial.to(your_order_summary_form)
 
     continue_from_what_is_your_address_form = initial.to(your_order_summary_form)
+
+    continue_from_your_order_type_other_and_dont_know_officer_form = initial.to(
+        your_contact_details_form
+    )
 
     continue_from_your_order_type_british_army_officer_form = initial.to(
         your_contact_details_form
@@ -465,6 +484,11 @@ class RoutingStateMachine(StateMachine):
     def entering_your_order_type_british_army_officer_form(self):
         self.route_for_current_state = (
             MultiPageFormRoutes.YOUR_ORDER_TYPE_BRITISH_ARMY_OFFICER.value
+        )
+
+    def entering_your_order_type_other_and_dont_know_officer_form(self):
+        self.route_for_current_state = (
+            MultiPageFormRoutes.YOUR_ORDER_TYPE_OTHER_AND_DONT_KNOW_OFFICER.value
         )
 
     def entering_choose_your_order_type_form(self):

--- a/app/main/forms/have_you_previously_made_a_request.py
+++ b/app/main/forms/have_you_previously_made_a_request.py
@@ -8,6 +8,7 @@ from wtforms import (
     RadioField,
     StringField,
     SubmitField,
+    HiddenField,
 )
 from wtforms.validators import InputRequired, Length
 
@@ -20,6 +21,10 @@ from app.main.forms.validation_helpers.text_field_conditionally_required import 
 
 class HaveYouPreviouslyMadeARequest(FlaskForm):
     content = load_content()
+
+    service_branch = HiddenField()
+
+    were_they_a_commissioned_officer = HiddenField()
 
     have_you_previously_made_a_request = RadioField(
         get_field_content(content, "have_you_previously_made_a_request", "label"),

--- a/app/main/forms/have_you_previously_made_a_request.py
+++ b/app/main/forms/have_you_previously_made_a_request.py
@@ -5,10 +5,10 @@ from tna_frontend_jinja.wtforms import (
     TnaTextInputWidget,
 )
 from wtforms import (
+    HiddenField,
     RadioField,
     StringField,
     SubmitField,
-    HiddenField,
 )
 from wtforms.validators import InputRequired, Length
 

--- a/app/main/forms/your_order_type_british_army_officers.py
+++ b/app/main/forms/your_order_type_british_army_officers.py
@@ -1,12 +1,13 @@
-from app.lib.content import get_field_content, load_content
 from flask_wtf import FlaskForm
 from tna_frontend_jinja.wtforms import (
     TnaSubmitWidget,
 )
 from wtforms import (
-    SubmitField,
     HiddenField,
+    SubmitField,
 )
+
+from app.lib.content import get_field_content, load_content
 
 
 class YourOrderTypeBritishArmyOfficers(FlaskForm):

--- a/app/main/forms/your_order_type_british_army_officers.py
+++ b/app/main/forms/your_order_type_british_army_officers.py
@@ -1,0 +1,22 @@
+from app.lib.content import get_field_content, load_content
+from flask_wtf import FlaskForm
+from tna_frontend_jinja.wtforms import (
+    TnaSubmitWidget,
+)
+from wtforms import (
+    SubmitField,
+    HiddenField,
+)
+
+
+class YourOrderTypeBritishArmyOfficers(FlaskForm):
+    content = load_content()
+
+    processing_option = HiddenField()
+
+    submit = SubmitField(
+        get_field_content(
+            content, "your_order_type_british_army_officers", "call_to_action"
+        ),
+        widget=TnaSubmitWidget(),
+    )

--- a/app/main/forms/your_order_type_other_and_dont_know_officers.py
+++ b/app/main/forms/your_order_type_other_and_dont_know_officers.py
@@ -1,4 +1,3 @@
-from app.lib.content import get_field_content, load_content
 from flask_wtf import FlaskForm
 from tna_frontend_jinja.wtforms import (
     TnaSubmitWidget,
@@ -7,6 +6,8 @@ from wtforms import (
     HiddenField,
     SubmitField,
 )
+
+from app.lib.content import get_field_content, load_content
 
 
 class YourOrderTypeOtherAndDontKnowOfficers(FlaskForm):

--- a/app/main/forms/your_order_type_other_and_dont_know_officers.py
+++ b/app/main/forms/your_order_type_other_and_dont_know_officers.py
@@ -1,0 +1,24 @@
+from app.lib.content import get_field_content, load_content
+from flask_wtf import FlaskForm
+from tna_frontend_jinja.wtforms import (
+    TnaSubmitWidget,
+)
+from wtforms import (
+    HiddenField,
+    SubmitField,
+)
+
+
+class YourOrderTypeOtherAndDontKnowOfficers(FlaskForm):
+    content = load_content()
+
+    processing_option = HiddenField()
+
+    submit = SubmitField(
+        get_field_content(
+            content,
+            "your_order_type_other_and_dont_know_officers",
+            "call_to_action",
+        ),
+        widget=TnaSubmitWidget(),
+    )

--- a/app/main/routes/routes.py
+++ b/app/main/routes/routes.py
@@ -243,6 +243,7 @@ def we_do_not_have_royal_navy_service_records(form, state_machine):
 @update_dynamic_back_link_mapping(
     mappings={
         MultiPageFormRoutes.WHAT_WAS_THEIR_DATE_OF_BIRTH: MultiPageFormRoutes.WE_ARE_UNLIKELY_TO_HOLD_OFFICER_RECORDS__ARMY,
+        MultiPageFormRoutes.YOUR_CONTACT_DETAILS: MultiPageFormRoutes.YOUR_ORDER_TYPE_BRITISH_ARMY_OFFICER,
     }
 )
 @with_state_machine
@@ -288,6 +289,7 @@ def we_are_unlikely_to_hold_officer_records__raf(form, state_machine):
 @update_dynamic_back_link_mapping(
     mappings={
         MultiPageFormRoutes.WHAT_WAS_THEIR_DATE_OF_BIRTH: MultiPageFormRoutes.WE_ARE_UNLIKELY_TO_HOLD_OFFICER_RECORDS__GENERIC,
+        MultiPageFormRoutes.YOUR_CONTACT_DETAILS: MultiPageFormRoutes.YOUR_ORDER_TYPE_OTHER_AND_DONT_KNOW_OFFICER,
     }
 )
 @with_form_prefilled_from_session(WeAreUnlikelyToHoldThisRecord)
@@ -463,7 +465,10 @@ def your_contact_details(form, state_machine):
         state_machine.continue_from_your_contact_details_form(form)
         return redirect(url_for(state_machine.route_for_current_state))
     return render_template(
-        "main/your-contact-details.html", form=form, content=load_content()
+        "main/your-contact-details.html",
+        form=form,
+        content=load_content(),
+        back_link_route=get_dynamic_back_link_route(key=request.endpoint),
     )
 
 
@@ -508,6 +513,11 @@ def what_is_your_address(form, state_machine):
 
 
 @bp.route("/choose-your-order-type/", methods=["GET", "POST"])
+@update_dynamic_back_link_mapping(
+    mappings={
+        MultiPageFormRoutes.YOUR_CONTACT_DETAILS: MultiPageFormRoutes.CHOOSE_YOUR_ORDER_TYPE,
+    }
+)
 @with_state_machine
 def choose_your_order_type(state_machine):
     form = ChooseYourOrderType()

--- a/app/main/routes/routes.py
+++ b/app/main/routes/routes.py
@@ -54,6 +54,13 @@ from app.main.forms.what_was_their_date_of_birth import WhatWasTheirDateOfBirth
 from app.main.forms.you_may_want_to_check_ancestry import YouMayWantToCheckAncestry
 from app.main.forms.your_contact_details import YourContactDetails
 from app.main.forms.your_order_summary import YourOrderSummary
+from app.main.forms.your_order_type_british_army_officers import (
+    YourOrderTypeBritishArmyOfficers,
+)
+from app.main.forms.your_order_type_other_and_dont_know_officers import (
+    YourOrderTypeOtherAndDontKnowOfficers,
+)
+
 from flask import redirect, render_template, request, session, url_for
 
 
@@ -628,6 +635,39 @@ def sorry_you_will_have_to_start_again(form, state_machine):
 
     return render_template(
         "main/sorry-you-will-have-to-start-again.html",
+        content=load_content(),
+        form=form,
+    )
+
+
+@bp.route("/your-order-type-british-army-officers/", methods=["GET", "POST"])
+@with_form_prefilled_from_session(YourOrderTypeBritishArmyOfficers)
+@with_state_machine
+def your_order_type_british_army_officers(form, state_machine):
+    if form.validate_on_submit():
+        save_submitted_form_fields_to_session(form)
+        state_machine.continue_from_your_order_type_british_army_officer_form(form)
+        return redirect(url_for(state_machine.route_for_current_state))
+
+    return render_template(
+        "main/your-order-type-british-army-officers.html",
+        content=load_content(),
+        form=form,
+    )
+
+
+@bp.route("/your-order-type-other-and-dont-know-officers/", methods=["GET", "POST"])
+@with_form_prefilled_from_session(YourOrderTypeOtherAndDontKnowOfficers)
+@with_state_machine
+def your_order_type_other_and_dont_know_officers(form, state_machine):
+    if form.validate_on_submit():
+        save_submitted_form_fields_to_session(form)
+        state_machine.continue_from_your_order_type_other_and_dont_know_officer_form(
+            form
+        )
+        return redirect(url_for(state_machine.route_for_current_state))
+    return render_template(
+        "main/your-order-type-other-and-dont-know-officers.html",
         content=load_content(),
         form=form,
     )

--- a/app/main/routes/routes.py
+++ b/app/main/routes/routes.py
@@ -54,6 +54,7 @@ from app.main.forms.what_was_their_date_of_birth import WhatWasTheirDateOfBirth
 from app.main.forms.you_may_want_to_check_ancestry import YouMayWantToCheckAncestry
 from app.main.forms.your_contact_details import YourContactDetails
 from app.main.forms.your_order_summary import YourOrderSummary
+from flask import redirect, render_template, request, session, url_for
 
 
 @bp.route("/", methods=["GET", "POST"])

--- a/app/main/routes/routes.py
+++ b/app/main/routes/routes.py
@@ -11,6 +11,9 @@ from app.lib.decorators.update_dynamic_back_link_mapping import (
 from app.lib.decorators.with_form_prefilled_from_session import (
     with_form_prefilled_from_session,
 )
+from app.lib.derive_if_change_order_is_available import (
+    derive_if_change_order_is_available,
+)
 from app.lib.get_dynamic_back_link_route import get_dynamic_back_link_route
 from app.lib.price_calculations import prepare_order_summary_data
 from app.lib.save_catalogue_reference_to_session import (
@@ -562,6 +565,8 @@ def your_order_summary(form, state_machine):
             url_for("main.start")
         )  # TODO: What should the user see if order summary fails?
 
+    can_change_order = derive_if_change_order_is_available(form_data)
+
     return render_template(
         "main/your-order-summary.html",
         content=load_content(),
@@ -569,6 +574,7 @@ def your_order_summary(form, state_machine):
         form_data=form_data,
         order_summary_data=order_summary_data,
         back_link_route=get_dynamic_back_link_route(key=request.endpoint),
+        can_change_order=can_change_order,
     )
 
 

--- a/app/main/routes/routes.py
+++ b/app/main/routes/routes.py
@@ -64,8 +64,6 @@ from app.main.forms.your_order_type_other_and_dont_know_officers import (
     YourOrderTypeOtherAndDontKnowOfficers,
 )
 
-from flask import redirect, render_template, request, session, url_for
-
 
 @bp.route("/", methods=["GET", "POST"])
 @with_state_machine

--- a/app/templates/macros/conditionally-available-link.html
+++ b/app/templates/macros/conditionally-available-link.html
@@ -1,0 +1,7 @@
+{% macro conditionallyAvailableLink(route_name, content, should_render=True) -%}
+  {% if should_render %}
+    <a href="{{ url_for(route_name) }}" class="tna-button tna-button--plain">
+      {{ content }}
+    </a>
+  {% endif %}
+{%- endmacro %}

--- a/app/templates/main/have-you-previously-made-a-request.html
+++ b/app/templates/main/have-you-previously-made-a-request.html
@@ -18,6 +18,8 @@
           class="tna-heading-xl tna-!--margin-top-m">{{ content.pages.have_you_previously_made_a_request.heading }}</h1>
         <form action="{{ url_for('main.have_you_previously_made_a_request') }}" method="post" novalidate>
           {{ form.csrf_token }}
+          {{ form.service_branch }}
+          {{ form.were_they_a_commissioned_officer }}
           <p>{{ content.pages.have_you_previously_made_a_request.prompt_to_provide_reference_number }}</p>
           {{ form.have_you_previously_made_a_request(params={'size':'m'}) }}
           {{ form.case_reference_number(params={'size':'m'}) }}

--- a/app/templates/main/your-contact-details.html
+++ b/app/templates/main/your-contact-details.html
@@ -3,7 +3,7 @@
 {%- set pageTitle = content.pages.your_contact_details.heading | prepare_page_title -%}
 
 {% block beforeContent %}
-  {{ backLink(url_for('main.choose_your_order_type')) }}
+  {{ backLink(url_for(back_link_route)) }}
 {% endblock beforeContent %}
 
 {% block content %}

--- a/app/templates/main/your-order-summary.html
+++ b/app/templates/main/your-order-summary.html
@@ -1,6 +1,7 @@
 {% extends "base.html" %}
 
 {%- from 'macros/order-price.html' import orderPrice %}
+{%- from 'macros/conditionally-available-link.html' import conditionallyAvailableLink %}
 
 {%- set pageTitle = content.pages.your_order_summary.heading | prepare_page_title -%}
 
@@ -48,9 +49,7 @@
           <form action="{{ url_for('main.your_order_summary') }}" method="post" novalidate>
             {{ form.csrf_token }}
             <div class="tna-button-group">
-              <a href="{{ url_for('main.choose_your_order_type') }}" class="tna-button tna-button--plain">
-                {{ content.pages.your_order_summary.change_order_type }}
-              </a>
+              {{ conditionallyAvailableLink('main.choose_your_order_type', content.pages.your_order_summary.change_order_type) }}
               {{ form.submit(params={'classes': 'tna-button--accent'}) }}
             </div>
           </form>

--- a/app/templates/main/your-order-summary.html
+++ b/app/templates/main/your-order-summary.html
@@ -49,7 +49,7 @@
           <form action="{{ url_for('main.your_order_summary') }}" method="post" novalidate>
             {{ form.csrf_token }}
             <div class="tna-button-group">
-              {{ conditionallyAvailableLink('main.choose_your_order_type', content.pages.your_order_summary.change_order_type) }}
+              {{ conditionallyAvailableLink('main.choose_your_order_type', content.pages.your_order_summary.change_order_type, can_change_order) }}
               {{ form.submit(params={'classes': 'tna-button--accent'}) }}
             </div>
           </form>

--- a/app/templates/main/your-order-type-british-army-officers.html
+++ b/app/templates/main/your-order-type-british-army-officers.html
@@ -1,0 +1,41 @@
+{% extends "base.html" %}
+
+{%- set pageTitle = content.pages.your_order_type_army_officer.heading | prepare_page_title -%}
+
+{% block beforeContent %}
+  {{ backLink(url_for('main.have_you_previously_made_a_request')) }}
+{% endblock beforeContent %}
+
+{% block content %}
+  <div class="tna-section tna-!--padding-top-s">
+    <div class="tna-container">
+      <div
+        class="tna-column tna-column--width-2-3 tna-column--width-5-6-medium tna-column--full-small tna-column--full-tiny">
+        <h1 class="tna-heading-xl tna-!--margin-top-m">{{ content.pages.your_order_type_army_officer.heading }}</h1>
+        {% for paragraph in content.pages.your_order_type_army_officer.paragraphs %}
+          <p>{{ paragraph }}</p>
+        {% endfor %}
+
+        <h2 class="tna-heading-l">{{ content.pages.your_order_type_army_officer.full_record_check.heading }}</h2>
+        {% for paragraph in content.pages.your_order_type_army_officer.full_record_check.paragraphs %}
+          <p>{{ paragraph }}</p>
+        {% endfor %}
+        {% if content.pages.your_order_type_army_officer.full_record_check.information_list.list_items %}
+          {{ descriptionList(content.pages.your_order_type_army_officer.full_record_check.information_list.list_items) }}
+        {% endif %}
+        {% for paragraph in content.pages.your_order_type_army_officer.final_paragraphs %}
+          <p>{{ paragraph }}</p>
+        {% endfor %}
+        <div class="tna-!--margin-top-m">
+          <form action="{{ url_for('main.your_order_type_british_army_officers') }}" method="post" novalidate>
+            {{ form.csrf_token }}
+            {{ form.processing_option(value='full', id='processing_option_full_record_check') }}
+            <div class="tna-button-group">
+              {{ form.submit(params={'classes': 'tna-button--accent'}) }}
+            </div>
+          </form>
+        </div>
+      </div>
+    </div>
+  </div>
+{% endblock content %}

--- a/app/templates/main/your-order-type-other-and-dont-know-officers.html
+++ b/app/templates/main/your-order-type-other-and-dont-know-officers.html
@@ -1,0 +1,43 @@
+{% extends "base.html" %}
+
+{%- set pageTitle = content.pages.your_order_type_other_and_dont_know_officers.heading | prepare_page_title -%}
+
+{% block beforeContent %}
+  {{ backLink(url_for('main.have_you_previously_made_a_request')) }}
+{% endblock beforeContent %}
+
+{% block content %}
+  <div class="tna-section tna-!--padding-top-s">
+    <div class="tna-container">
+      <div
+        class="tna-column tna-column--width-2-3 tna-column--width-5-6-medium tna-column--full-small tna-column--full-tiny">
+        <h1
+          class="tna-heading-xl tna-!--margin-top-m">{{ content.pages.your_order_type_other_and_dont_know_officers.heading }}</h1>
+        {% for paragraph in content.pages.your_order_type_other_and_dont_know_officers.paragraphs %}
+          <p>{{ paragraph }}</p>
+        {% endfor %}
+
+        <h2
+          class="tna-heading-l">{{ content.pages.your_order_type_other_and_dont_know_officers.full_record_check.heading }}</h2>
+        {% for paragraph in content.pages.your_order_type_other_and_dont_know_officers.full_record_check.paragraphs %}
+          <p>{{ paragraph }}</p>
+        {% endfor %}
+        {% if content.pages.your_order_type_other_and_dont_know_officers.full_record_check.information_list.list_items %}
+          {{ descriptionList(content.pages.your_order_type_other_and_dont_know_officers.full_record_check.information_list.list_items) }}
+        {% endif %}
+        {% for paragraph in content.pages.your_order_type_other_and_dont_know_officers.final_paragraphs %}
+          <p>{{ paragraph }}</p>
+        {% endfor %}
+        <div class="tna-!--margin-top-m">
+          <form action="{{ url_for('main.your_order_type_other_and_dont_know_officers') }}" method="post" novalidate>
+            {{ form.csrf_token }}
+            {{ form.processing_option(value='full', id='processing_option_full_record_check') }}
+            <div class="tna-button-group">
+              {{ form.submit(params={'classes': 'tna-button--accent'}) }}
+            </div>
+          </form>
+        </div>
+      </div>
+    </div>
+  </div>
+{% endblock content %}

--- a/test/lib/test_derive_if_change_order_is_available.py
+++ b/test/lib/test_derive_if_change_order_is_available.py
@@ -1,0 +1,81 @@
+"""
+Unit tests for derive_if_change_order_is_available function.
+"""
+
+from app.lib.derive_if_change_order_is_available import (
+    derive_if_change_order_is_available,
+)
+
+
+class TestDeriveIfChangeOrderIsAvailable:
+    """Test suite for derive_if_change_order_is_available function."""
+
+    # Tests for non-officer status
+    def test_returns_true_when_service_person_is_not_an_officer(self):
+        """Test that True is returned when service person is not an officer."""
+        form_data = {
+            "were_they_a_commissioned_officer": "no",
+            "service_branch": "BRITISH_ARMY",
+        }
+        assert derive_if_change_order_is_available(form_data) is True
+
+    def test_returns_true_for_non_officer_regardless_of_service_branch(self):
+        """Test that True is returned for non-officer regardless of service branch."""
+        service_branches = [
+            "ROYAL_NAVY",
+            "BRITISH_ARMY",
+            "ROYAL_AIR_FORCE",
+            "HOME_GUARD",
+            "OTHER",
+            "UNKNOWN",
+        ]
+        for branch in service_branches:
+            form_data = {
+                "were_they_a_commissioned_officer": "no",
+                "service_branch": branch,
+            }
+            assert derive_if_change_order_is_available(form_data) is True
+
+    # Tests for officer status with RAF
+    def test_returns_true_when_officer_and_service_branch_is_raf(self):
+        """Test that True is returned when service person is an officer in RAF."""
+        form_data = {
+            "were_they_a_commissioned_officer": "yes",
+            "service_branch": "ROYAL_AIR_FORCE",
+        }
+        assert derive_if_change_order_is_available(form_data) is True
+
+    # Tests for officer status without RAF
+    def test_returns_false_when_officer_and_service_branch_is_not_raf(self):
+        """Test that False is returned when service person is an officer but not in RAF."""
+        service_branches = [
+            "ROYAL_NAVY",
+            "BRITISH_ARMY",
+            "HOME_GUARD",
+            "OTHER",
+            "UNKNOWN",
+        ]
+        for branch in service_branches:
+            form_data = {
+                "were_they_a_commissioned_officer": "yes",
+                "service_branch": branch,
+            }
+            assert derive_if_change_order_is_available(form_data) is False
+
+    # Tests for unknown officer status
+    def test_returns_false_when_officer_status_is_unknown(self):
+        """Test that False is returned when officer status is unknown."""
+        service_branches = [
+            "ROYAL_NAVY",
+            "BRITISH_ARMY",
+            "ROYAL_AIR_FORCE",
+            "HOME_GUARD",
+            "OTHER",
+            "UNKNOWN",
+        ]
+        for branch in service_branches:
+            form_data = {
+                "were_they_a_commissioned_officer": "unknown",
+                "service_branch": branch,
+            }
+            assert derive_if_change_order_is_available(form_data) is False

--- a/test/lib/test_derive_if_change_order_is_available.py
+++ b/test/lib/test_derive_if_change_order_is_available.py
@@ -78,4 +78,4 @@ class TestDeriveIfChangeOrderIsAvailable:
                 "were_they_a_commissioned_officer": "unknown",
                 "service_branch": branch,
             }
-            assert derive_if_change_order_is_available(form_data) is False
+            assert derive_if_change_order_is_available(form_data) is True

--- a/test/lib/test_template_macro_conditionally_available_link.py
+++ b/test/lib/test_template_macro_conditionally_available_link.py
@@ -1,0 +1,64 @@
+import pytest
+from flask import url_for
+from werkzeug.routing import BuildError
+
+from app import create_app
+
+
+@pytest.fixture
+def app():
+    return create_app("config.Test")
+
+
+def test_conditionally_available_link_renders_route_href_text_and_classes(app):
+    with app.test_request_context():
+        macro_template = app.jinja_env.get_template(
+            "macros/conditionally-available-link.html"
+        )
+        rendered = macro_template.module.conditionallyAvailableLink(
+            "main.choose_your_order_type", "Change order type", True
+        )
+
+        expected_href = url_for("main.choose_your_order_type")
+
+    assert f'href="{expected_href}"' in rendered
+    assert "Change order type" in rendered
+
+
+def test_conditionally_available_link_raises_for_invalid_route_name(app):
+    with app.test_request_context():
+        macro_template = app.jinja_env.get_template(
+            "macros/conditionally-available-link.html"
+        )
+
+        with pytest.raises(BuildError):
+            macro_template.module.conditionallyAvailableLink(
+                "main.not_a_real_route", "Broken", True
+            )
+
+
+def test_conditionally_available_link_renders_nothing_when_flag_is_false(app):
+    with app.test_request_context():
+        macro_template = app.jinja_env.get_template(
+            "macros/conditionally-available-link.html"
+        )
+        rendered = macro_template.module.conditionallyAvailableLink(
+            "main.choose_your_order_type", "Change order type", False
+        )
+
+    assert rendered.strip() == ""
+
+
+def test_conditionally_available_link_renders_when_should_render_omitted(app):
+    with app.test_request_context():
+        macro_template = app.jinja_env.get_template(
+            "macros/conditionally-available-link.html"
+        )
+        rendered = macro_template.module.conditionallyAvailableLink(
+            "main.choose_your_order_type", "Change order type"
+        )
+
+        expected_href = url_for("main.choose_your_order_type")
+
+    assert f'href="{expected_href}"' in rendered
+    assert "Change order type" in rendered

--- a/test/lib/test_template_macro_conditionally_available_link.py
+++ b/test/lib/test_template_macro_conditionally_available_link.py
@@ -16,13 +16,13 @@ def test_conditionally_available_link_renders_route_href_text_and_classes(app):
             "macros/conditionally-available-link.html"
         )
         rendered = macro_template.module.conditionallyAvailableLink(
-            "main.choose_your_order_type", "Change order type", True
+            "main.choose_your_order_type", "Change order", True
         )
 
         expected_href = url_for("main.choose_your_order_type")
 
     assert f'href="{expected_href}"' in rendered
-    assert "Change order type" in rendered
+    assert "Change order" in rendered
 
 
 def test_conditionally_available_link_raises_for_invalid_route_name(app):
@@ -43,7 +43,7 @@ def test_conditionally_available_link_renders_nothing_when_flag_is_false(app):
             "macros/conditionally-available-link.html"
         )
         rendered = macro_template.module.conditionallyAvailableLink(
-            "main.choose_your_order_type", "Change order type", False
+            "main.choose_your_order_type", "Change order", False
         )
 
     assert rendered.strip() == ""
@@ -55,10 +55,10 @@ def test_conditionally_available_link_renders_when_should_render_omitted(app):
             "macros/conditionally-available-link.html"
         )
         rendered = macro_template.module.conditionallyAvailableLink(
-            "main.choose_your_order_type", "Change order type"
+            "main.choose_your_order_type", "Change order"
         )
 
         expected_href = url_for("main.choose_your_order_type")
 
     assert f'href="{expected_href}"' in rendered
-    assert "Change order type" in rendered
+    assert "Change order" in rendered

--- a/test/main/test_state_machine.py
+++ b/test/main/test_state_machine.py
@@ -448,6 +448,7 @@ def test_continue_from_have_you_previously_made_a_request():
             service_number=None,
             regiment=None,
             additional_information=None,
+            were_they_a_commissioned_officer=None,
             submit=None,
         )
     )
@@ -623,3 +624,10 @@ def test_continue_from_sorry_you_will_have_to_start_again():
     )
     assert sm.current_state.id == "service_start_page"
     assert sm.route_for_current_state == MultiPageFormRoutes.JOURNEY_START.value
+
+
+def test_continue_from_your_order_type_british_army_officer_form():
+    sm = RoutingStateMachine()
+    sm.continue_from_your_order_type_british_army_officer_form()
+    assert sm.current_state.id == "your_contact_details_form"
+    assert sm.route_for_current_state == MultiPageFormRoutes.YOUR_CONTACT_DETAILS.value

--- a/test/main/test_state_machine.py
+++ b/test/main/test_state_machine.py
@@ -435,11 +435,56 @@ def test_continue_from_service_person_details():
     )
 
 
-def test_continue_from_have_you_previously_made_a_request():
+@pytest.mark.parametrize(
+    "service_branch,was_officer,expected_state,expected_route",
+    [
+        (
+            "BRITISH_ARMY",
+            "yes",
+            "your_order_type_british_army_officer_form",
+            MultiPageFormRoutes.YOUR_ORDER_TYPE_BRITISH_ARMY_OFFICER.value,
+        ),
+        (
+            "BRITISH_ARMY",
+            "no",
+            "choose_your_order_type_form",
+            MultiPageFormRoutes.CHOOSE_YOUR_ORDER_TYPE.value,
+        ),
+        (
+            "OTHER",
+            "yes",
+            "your_order_type_other_and_dont_know_officer_form",
+            MultiPageFormRoutes.YOUR_ORDER_TYPE_OTHER_AND_DONT_KNOW_OFFICER.value,
+        ),
+        (
+            "OTHER",
+            "no",
+            "choose_your_order_type_form",
+            MultiPageFormRoutes.CHOOSE_YOUR_ORDER_TYPE.value,
+        ),
+        (
+            "UNKNOWN",
+            "yes",
+            "your_order_type_other_and_dont_know_officer_form",
+            MultiPageFormRoutes.YOUR_ORDER_TYPE_OTHER_AND_DONT_KNOW_OFFICER.value,
+        ),
+        (
+            "UNKNOWN",
+            "no",
+            "choose_your_order_type_form",
+            MultiPageFormRoutes.CHOOSE_YOUR_ORDER_TYPE.value,
+        ),
+    ],
+)
+def test_continue_from_have_you_previously_made_a_request_routes_by_condition(
+    service_branch, was_officer, expected_state, expected_route
+):
     sm = RoutingStateMachine()
 
     sm.continue_from_have_you_previously_made_a_request_form(
         form=make_form(
+            service_branch=service_branch,
+            were_they_a_commissioned_officer=was_officer,
             forenames=None,
             last_name=None,
             place_of_birth=None,
@@ -448,10 +493,12 @@ def test_continue_from_have_you_previously_made_a_request():
             service_number=None,
             regiment=None,
             additional_information=None,
-            were_they_a_commissioned_officer=None,
             submit=None,
         )
     )
+
+    assert sm.current_state.id == expected_state
+    assert sm.route_for_current_state == expected_route
 
 
 @pytest.mark.parametrize(

--- a/test/playwright/end-to-end/test-cases/your-order-type-variants/army-officer.ts
+++ b/test/playwright/end-to-end/test-cases/your-order-type-variants/army-officer.ts
@@ -1,0 +1,35 @@
+export const armyOfficer = {
+  firstName: "Jeremiah",
+  lastName: "Thompson",
+  otherLastNames: "Miller",
+  serviceNumber: "T2156487",
+  placeOfBirth: "Manchester",
+  dateOfBirth: {
+    day: "23",
+    month: "03",
+    year: "1918",
+  },
+  serviceBranch: "British Army",
+  wasOfficer: "Yes",
+  isAlive: "No",
+  dateOfDeath: {
+    day: "12",
+    month: "07",
+    year: "2003",
+  },
+  hasDeathCertificate: "Yes",
+  hasPreviouslyMadeRequest: "No",
+  orderSelection: "Choose standard",
+  didTheyDieInService: "No",
+  regimentOrSquadron: "Royal Artillery",
+  additionalInformation: `
+    Jeremiah Thompson served in the Royal Artillery during World War II.
+    He served in North Africa, Sicily, Italy, France and Germany.
+    He was promoted to Sergeant in 1942 and remained in service until 1946.
+  `,
+  personMakingRequest: {
+    firstName: "Margaret",
+    lastName: "Thompson",
+    emailAddress: "margaret.thompson@example.com",
+  },
+};

--- a/test/playwright/end-to-end/test-cases/your-order-type-variants/other-officer.ts
+++ b/test/playwright/end-to-end/test-cases/your-order-type-variants/other-officer.ts
@@ -1,0 +1,35 @@
+export const otherOfficer = {
+  firstName: "Alfred",
+  lastName: "Bennett",
+  otherLastNames: "Carter",
+  serviceNumber: "B3075194",
+  placeOfBirth: "Liverpool",
+  dateOfBirth: {
+    day: "09",
+    month: "11",
+    year: "1917",
+  },
+  serviceBranch: "Other",
+  wasOfficer: "Yes",
+  isAlive: "No",
+  dateOfDeath: {
+    day: "18",
+    month: "04",
+    year: "2001",
+  },
+  hasDeathCertificate: "Yes",
+  hasPreviouslyMadeRequest: "No",
+  orderSelection: "Choose Full record check",
+  didTheyDieInService: "No",
+  regimentOrSquadron: "Royal Engineers",
+  additionalInformation: `
+    Alfred Bennett served in the Royal Engineers during World War II.
+    He served in Egypt, Italy, Belgium, the Netherlands and Germany.
+    He was injured in 1944 and later returned to duty before leaving service in 1946.
+  `,
+  personMakingRequest: {
+    firstName: "Elaine",
+    lastName: "Bennett",
+    emailAddress: "elaine.bennett@example.com",
+  },
+};

--- a/test/playwright/end-to-end/test-cases/your-order-type-variants/unknown-officer.ts
+++ b/test/playwright/end-to-end/test-cases/your-order-type-variants/unknown-officer.ts
@@ -1,0 +1,35 @@
+export const unknownOfficer = {
+  firstName: "Harold",
+  lastName: "Sinclair",
+  otherLastNames: "Davies",
+  serviceNumber: "S4821736",
+  placeOfBirth: "Bristol",
+  dateOfBirth: {
+    day: "27",
+    month: "02",
+    year: "1916",
+  },
+  serviceBranch: "I do not know",
+  wasOfficer: "Yes",
+  isAlive: "No",
+  dateOfDeath: {
+    day: "05",
+    month: "10",
+    year: "1999",
+  },
+  hasDeathCertificate: "Yes",
+  hasPreviouslyMadeRequest: "No",
+  orderSelection: "Choose standard",
+  didTheyDieInService: "No",
+  regimentOrSquadron: "Royal Signals",
+  additionalInformation: `
+    Harold Sinclair served with the Royal Signals during World War II.
+    He served in Malta, Tunisia, Sicily, Italy and Austria.
+    He was commissioned in 1943 and remained in service until 1947.
+  `,
+  personMakingRequest: {
+    firstName: "Janet",
+    lastName: "Sinclair",
+    emailAddress: "janet.sinclair@example.com",
+  },
+};

--- a/test/playwright/end-to-end/to-order-summary-and-back.spec.ts
+++ b/test/playwright/end-to-end/to-order-summary-and-back.spec.ts
@@ -71,10 +71,9 @@ test.describe("End-to-end journey", () => {
         "",
       );
       await continueFromServicePersonDetails(page, robertHughJones);
-      await continueFromHaveYouPreviouslyMadeARequest(
-        page,
-        robertHughJones.hasPreviouslyMadeRequest,
-      );
+      await continueFromHaveYouPreviouslyMadeARequest(page, {
+        label: robertHughJones.hasPreviouslyMadeRequest,
+      });
       await continueFromChooseYourOrderType(
         page,
         robertHughJones.orderSelection,

--- a/test/playwright/lib/constants.ts
+++ b/test/playwright/lib/constants.ts
@@ -31,6 +31,7 @@ export const Paths = {
   WHAT_WAS_THEIR_DATE_OF_BIRTH: `${basePath}/what-was-their-date-of-birth/`,
   YOUR_CONTACT_DETAILS: `${basePath}/your-contact-details/`,
   WHAT_IS_YOUR_ADDRESS: `${basePath}/what-is-your-address/`,
+  YOUR_ORDER_TYPE_BRITISH_ARMY_OFFICERS: `${basePath}/your-order-type-british-army-officers/`,
   YOUR_ORDER_SUMMARY: `${basePath}/your-order-summary/`,
   NOT_A_VALID_LINK: `${basePath}/not-a-valid-second-payment-link/`,
   PAYMENT_LINK_EXPIRED: `${basePath}/second-payment-link-expired/`,

--- a/test/playwright/lib/constants.ts
+++ b/test/playwright/lib/constants.ts
@@ -32,6 +32,7 @@ export const Paths = {
   YOUR_CONTACT_DETAILS: `${basePath}/your-contact-details/`,
   WHAT_IS_YOUR_ADDRESS: `${basePath}/what-is-your-address/`,
   YOUR_ORDER_TYPE_BRITISH_ARMY_OFFICERS: `${basePath}/your-order-type-british-army-officers/`,
+  YOUR_ORDER_TYPE_OTHER_AND_DONT_KNOW_OFFICERS: `${basePath}/your-order-type-other-and-dont-know-officers/`,
   YOUR_ORDER_SUMMARY: `${basePath}/your-order-summary/`,
   NOT_A_VALID_LINK: `${basePath}/not-a-valid-second-payment-link/`,
   PAYMENT_LINK_EXPIRED: `${basePath}/second-payment-link-expired/`,

--- a/test/playwright/lib/step-functions.ts
+++ b/test/playwright/lib/step-functions.ts
@@ -530,3 +530,14 @@ export async function continueFromYourOrderTypeBritishArmyOfficers(page) {
     .click();
   await expect(page).toHaveURL(Paths.YOUR_CONTACT_DETAILS);
 }
+
+export async function continueFromYourOrderTypeOtherAndDontKnowOfficers(page) {
+  await expect(page).toHaveURL(
+    Paths.YOUR_ORDER_TYPE_OTHER_AND_DONT_KNOW_OFFICERS,
+  );
+  await expect(page.locator("h1")).toHaveText(/Your order type/);
+  await page
+    .getByRole("button", { name: "Request a Full record check" })
+    .click();
+  await expect(page).toHaveURL(Paths.YOUR_CONTACT_DETAILS);
+}

--- a/test/playwright/lib/step-functions.ts
+++ b/test/playwright/lib/step-functions.ts
@@ -154,7 +154,7 @@ export async function continueFromWeAreUnlikelyToHoldThisRecord(
 ) {
   await expect(page).toHaveURL(pathVariant);
   await expect(page.locator("h1")).toHaveText(
-    /We are unlikely to hold this record/,
+    /We are unlikely to hold this record yet/,
   );
   await clickContinueThisRequestForm(page, "button");
 }
@@ -382,9 +382,12 @@ export async function continueFromServicePersonDetails(
 
 export async function continueFromHaveYouPreviouslyMadeARequest(
   page: any,
-  label: any,
-  errorMessage?: any,
-  populatedReferenceNumber?: any,
+  {
+    label = null,
+    errorMessage = null,
+    populatedReferenceNumber = null,
+    nextPath = null,
+  },
 ) {
   await expect(page).toHaveURL(Paths.HAVE_YOU_PREVIOUSLY_MADE_A_REQUEST);
   await expect(page.locator("h1")).toHaveText(
@@ -401,7 +404,7 @@ export async function continueFromHaveYouPreviouslyMadeARequest(
         errorMessage,
       );
     } else {
-      await expect(page).toHaveURL(Paths.CHOOSE_YOUR_ORDER_TYPE);
+      await expect(page).toHaveURL(nextPath || Paths.CHOOSE_YOUR_ORDER_TYPE);
     }
   }
 }
@@ -517,4 +520,13 @@ export async function clickContinueThisRequestForm(page, element) {
 export async function clickBackLink(page, expectedPath) {
   await page.getByRole("link", { name: "Back", exact: true }).click();
   await expect(page).toHaveURL(expectedPath);
+}
+
+export async function continueFromYourOrderTypeBritishArmyOfficers(page) {
+  await expect(page).toHaveURL(Paths.YOUR_ORDER_TYPE_BRITISH_ARMY_OFFICERS);
+  await expect(page.locator("h1")).toHaveText(/Your order type/);
+  await page
+    .getByRole("button", { name: "Request a Full record check" })
+    .click();
+  await expect(page).toHaveURL(Paths.YOUR_CONTACT_DETAILS);
 }

--- a/test/playwright/lib/step-functions.ts
+++ b/test/playwright/lib/step-functions.ts
@@ -549,13 +549,17 @@ export async function continueFromYourOrderTypeOtherAndDontKnowOfficers(page) {
 export async function continueToChooseYourOrderTypeFromJourneyStart(
   page,
   {
-    isAlive,
+    isAlive = "No",
     serviceBranch,
     wasOfficer,
+    nextUrlAfterOfficerSelection = Paths.WE_MAY_HOLD_THIS_RECORD,
+    expectedTemplateIdentifier = "we-may-hold-this-record--generic",
   }: {
-    isAlive: string;
+    isAlive?: string;
     serviceBranch: string;
     wasOfficer: string;
+    nextUrlAfterOfficerSelection?: string;
+    expectedTemplateIdentifier?: string;
   },
 ) {
   await page.goto(Paths.JOURNEY_START);
@@ -576,8 +580,8 @@ export async function continueToChooseYourOrderTypeFromJourneyStart(
   await continueFromWereTheyACommissionedOfficer(
     page,
     wasOfficer,
-    Paths.WE_MAY_HOLD_THIS_RECORD,
-    "we-may-hold-this-record--generic",
+    nextUrlAfterOfficerSelection,
+    expectedTemplateIdentifier,
   );
 
   await page.goto(Paths.CHOOSE_YOUR_ORDER_TYPE);

--- a/test/playwright/lib/step-functions.ts
+++ b/test/playwright/lib/step-functions.ts
@@ -541,3 +541,44 @@ export async function continueFromYourOrderTypeOtherAndDontKnowOfficers(page) {
     .click();
   await expect(page).toHaveURL(Paths.YOUR_CONTACT_DETAILS);
 }
+
+/**
+ * Builds the journey state needed for order-summary tests, then navigates
+ * directly to Choose your order type once the required prior answers are set.
+ */
+export async function continueToChooseYourOrderTypeFromJourneyStart(
+  page,
+  {
+    isAlive,
+    serviceBranch,
+    wasOfficer,
+  }: {
+    isAlive: string;
+    serviceBranch: string;
+    wasOfficer: string;
+  },
+) {
+  await page.goto(Paths.JOURNEY_START);
+  await continueFromJourneyStart(page);
+  await continueFromHowWeProcessRequests(page);
+  await continueFromBeforeYouStart(page, true);
+  await continueFromYouMayWantToCheckAncestry(page);
+  await continueFromIsServicePersonAlive(
+    page,
+    isAlive,
+    Paths.WHICH_MILITARY_BRANCH_DID_THE_PERSON_SERVE_IN,
+  );
+  await continueFromWhichMilitaryBranchDidThePersonServeIn(
+    page,
+    serviceBranch,
+    Paths.WERE_THEY_A_COMMISSIONED_OFFICER,
+  );
+  await continueFromWereTheyACommissionedOfficer(
+    page,
+    wasOfficer,
+    Paths.WE_MAY_HOLD_THIS_RECORD,
+    "we-may-hold-this-record--generic",
+  );
+
+  await page.goto(Paths.CHOOSE_YOUR_ORDER_TYPE);
+}

--- a/test/playwright/state-transitions/have-you-previously-made-a-request.spec.ts
+++ b/test/playwright/state-transitions/have-you-previously-made-a-request.spec.ts
@@ -21,12 +21,12 @@ test.describe("have you previously made a request", () => {
     test("without a selection, the user is shown an error message", async ({
       page,
     }) => {
-      await continueFromHaveYouPreviouslyMadeARequest(
-        page,
-        "",
-        /Tell us if you have made a request for this record before/,
-        false,
-      );
+      await continueFromHaveYouPreviouslyMadeARequest(page, {
+        label: "",
+        errorMessage:
+          /Tell us if you have made a request for this record before/,
+        populatedReferenceNumber: false,
+      });
     });
 
     const selectionMappings = [
@@ -34,52 +34,51 @@ test.describe("have you previously made a request", () => {
         description:
           "with 'No' selected the user proceeds to the 'Choose your order type' page",
         label: "No",
-        populateReferenceNumber: false,
+        populatedReferenceNumber: false,
       },
       {
         description:
           "with MoD selected and no reference number provided, there is an error message",
         label: "Yes, to the Ministry of Defence",
-        populateReferenceNumber: false,
+        populatedReferenceNumber: false,
         errorMessage: /Enter the reference number for your previous request/,
       },
       {
         description:
           "with TNA selected and no reference number provided, there is an error message",
         label: "Yes, to The National Archives",
-        populateReferenceNumber: false,
+        populatedReferenceNumber: false,
         errorMessage: /Enter the reference number for your previous request/,
       },
       {
         description:
           "with TNA selected and an excessively long reference number provided, there is an error message",
         label: "Yes, to The National Archives",
-        populateReferenceNumber: "abcdefghijklmnopqrstuvwxyz".repeat(4),
+        populatedReferenceNumber: "abcdefghijklmnopqrstuvwxyz".repeat(4),
         errorMessage: /Reference number must be 64 characters or less/,
       },
       {
         description:
           "with MoD selected and a reference number provided, the user proceeds to the 'Choose your order type' page",
         label: "Yes, to the Ministry of Defence",
-        populateReferenceNumber: "ABC 123",
+        populatedReferenceNumber: "ABC 123",
       },
       {
         description:
           "with TNA selected and a reference number provided, the user proceeds to the 'Choose your order type' page",
         label: "Yes, to The National Archives",
-        populateReferenceNumber: "ABC 123",
+        populatedReferenceNumber: "ABC 123",
       },
     ];
 
     selectionMappings.forEach(
-      ({ description, label, errorMessage, populateReferenceNumber }) => {
+      ({ description, label, errorMessage, populatedReferenceNumber }) => {
         test(description, async ({ page }) => {
-          await continueFromHaveYouPreviouslyMadeARequest(
-            page,
+          await continueFromHaveYouPreviouslyMadeARequest(page, {
             label,
             errorMessage,
-            populateReferenceNumber,
-          );
+            populatedReferenceNumber,
+          });
         });
       },
     );

--- a/test/playwright/state-transitions/we-are-unlikely-to-hold-officer-records__army.spec.ts
+++ b/test/playwright/state-transitions/we-are-unlikely-to-hold-officer-records__army.spec.ts
@@ -12,6 +12,14 @@ test.describe("The variant of 'We are unlikely to hold this record' for Army Off
     await page.goto(Paths.WE_ARE_UNLIKELY_TO_HOLD_OFFICER_RECORDS__ARMY);
   });
 
+  test("tells users that Full record check is the only order option", async ({
+    page,
+  }) => {
+    await expect(page.locator("main")).toHaveText(
+      /British Army Commissioned Officer records can only be requested from us using a Full record check/,
+    );
+  });
+
   test("the link inviting users to participate in user research is correct", async ({
     page,
   }) => {

--- a/test/playwright/state-transitions/we-are-unlikely-to-hold-officer-records__army.spec.ts
+++ b/test/playwright/state-transitions/we-are-unlikely-to-hold-officer-records__army.spec.ts
@@ -16,7 +16,7 @@ test.describe("The variant of 'We are unlikely to hold this record' for Army Off
     page,
   }) => {
     await expect(page.locator("main")).toHaveText(
-      /British Army Commissioned Officer records can only be requested from us using a Full record check/,
+      /These records can only be requested from us using a Full record check/,
     );
   });
 

--- a/test/playwright/state-transitions/we-are-unlikely-to-hold-officer-records__generic.spec.ts
+++ b/test/playwright/state-transitions/we-are-unlikely-to-hold-officer-records__generic.spec.ts
@@ -12,6 +12,17 @@ test.describe("The variant of 'We are unlikely to hold this record' for Army Off
     await page.goto(Paths.WE_ARE_UNLIKELY_TO_HOLD_OFFICER_RECORDS__GENERIC);
   });
 
+  test("tells users that Full record check is the only order option", async ({
+    page,
+  }) => {
+    await expect(page.locator("main")).toHaveText(
+      /Unless they served in the Royal Air Force/,
+    );
+    await expect(page.locator("main")).toHaveText(
+      /Commissioned Officer records can only be requested from us using a Full record check/,
+    );
+  });
+
   test("the 'Request from the Ministry of Defence' link is correct", async ({
     page,
   }) => {

--- a/test/playwright/state-transitions/we-are-unlikely-to-hold-officer-records__raf.spec.ts
+++ b/test/playwright/state-transitions/we-are-unlikely-to-hold-officer-records__raf.spec.ts
@@ -12,6 +12,14 @@ test.describe("The variant of 'We are unlikely to hold this record' for Army Off
     await page.goto(Paths.WE_ARE_UNLIKELY_TO_HOLD_OFFICER_RECORDS__RAF);
   });
 
+  test("tells users RAF records are currently being transferred", async ({
+    page,
+  }) => {
+    await expect(page.locator("main")).toHaveText(
+      /Royal Air Force Commissioned Officer records are currently being transferred to us/,
+    );
+  });
+
   test("the link inviting users to participate in user research is correct", async ({
     page,
   }) => {

--- a/test/playwright/state-transitions/your-order-summary.spec.ts
+++ b/test/playwright/state-transitions/your-order-summary.spec.ts
@@ -10,6 +10,7 @@ import {
 
 test.describe("Routes to 'Your order summary'", () => {
   test.beforeEach(async ({ page }) => {
+    test.setTimeout(120_000); // Increase timeout to 2 minutes for this test because it is end-to-end
     await continueToChooseYourOrderTypeFromJourneyStart(page, {
       isAlive: "No",
       serviceBranch: "British Army",
@@ -134,6 +135,72 @@ test.describe("Routes to 'Your order summary'", () => {
       await continueFromYourContactDetails(page, personMakingRequest);
       await page.getByRole("link", { name: "Change order" }).click();
       await expect(page).toHaveURL(Paths.CHOOSE_YOUR_ORDER_TYPE);
+    });
+  }
+});
+
+test.describe("'Change order' availability rules on 'Your order summary'", () => {
+  // These are just a sample of combinations - the full range of combinations is
+  // covered by unit tests.
+  const changeOrderAvailabilityScenarios = [
+    {
+      description: "when the service person was not an officer",
+      serviceBranch: "British Army",
+      wasOfficer: "No",
+      nextUrlAfterOfficerSelection: Paths.WE_MAY_HOLD_THIS_RECORD,
+      expectedTemplateIdentifier: "we-may-hold-this-record--generic",
+      isChangeOrderAvailable: true,
+    },
+    {
+      description:
+        "when the service person was an officer in the Royal Air Force",
+      serviceBranch: "Royal Air Force",
+      wasOfficer: "Yes",
+      nextUrlAfterOfficerSelection:
+        Paths.WE_ARE_UNLIKELY_TO_HOLD_OFFICER_RECORDS__RAF,
+      expectedTemplateIdentifier: "unlikely-to-hold--raf-officer-records",
+      isChangeOrderAvailable: true,
+    },
+    {
+      description: "when the service person was an officer in a non-RAF branch",
+      serviceBranch: "British Army",
+      wasOfficer: "Yes",
+      nextUrlAfterOfficerSelection:
+        Paths.WE_ARE_UNLIKELY_TO_HOLD_OFFICER_RECORDS__ARMY,
+      expectedTemplateIdentifier: "unlikely-to-hold--army-officer-records",
+      isChangeOrderAvailable: false,
+    },
+    {
+      description: "when officer status is unknown",
+      serviceBranch: "Royal Air Force",
+      wasOfficer: "I do not know",
+      nextUrlAfterOfficerSelection: Paths.WE_MAY_HOLD_THIS_RECORD,
+      expectedTemplateIdentifier: "we-may-hold-this-record--generic",
+      isChangeOrderAvailable: false,
+    },
+  ];
+
+  for (const scenario of changeOrderAvailabilityScenarios) {
+    test(`the 'Change order' link is ${scenario.isChangeOrderAvailable ? "" : "not "}shown ${scenario.description}`, async ({
+      page,
+    }) => {
+      await continueToChooseYourOrderTypeFromJourneyStart(page, scenario);
+      await continueFromChooseYourOrderType(page, "Choose standard");
+      await continueFromYourContactDetails(page, {
+        firstName: "Francis",
+        lastName: "Palgrave",
+        emailAddress: "test@example.com",
+      });
+
+      const changeOrderLink = page.getByRole("link", { name: "Change order" });
+
+      if (scenario.isChangeOrderAvailable) {
+        await expect(changeOrderLink).toBeVisible();
+        await changeOrderLink.click();
+        await expect(page).toHaveURL(Paths.CHOOSE_YOUR_ORDER_TYPE);
+      } else {
+        await expect(changeOrderLink).toHaveCount(0);
+      }
     });
   }
 });

--- a/test/playwright/state-transitions/your-order-summary.spec.ts
+++ b/test/playwright/state-transitions/your-order-summary.spec.ts
@@ -5,12 +5,16 @@ import {
   continueFromChooseYourOrderType,
   continueFromYourContactDetails,
   continueFromYourPostalAddress,
+  continueToChooseYourOrderTypeFromJourneyStart,
 } from "../lib/step-functions";
 
 test.describe("Routes to 'Your order summary'", () => {
   test.beforeEach(async ({ page }) => {
-    await page.goto(Paths.JOURNEY_START);
-    await page.goto(Paths.CHOOSE_YOUR_ORDER_TYPE);
+    await continueToChooseYourOrderTypeFromJourneyStart(page, {
+      isAlive: "No",
+      serviceBranch: "British Army",
+      wasOfficer: "No",
+    });
   });
 
   const providedByPostTests = [

--- a/test/playwright/state-transitions/your-order-summary.spec.ts
+++ b/test/playwright/state-transitions/your-order-summary.spec.ts
@@ -176,7 +176,7 @@ test.describe("'Change order' availability rules on 'Your order summary'", () =>
       wasOfficer: "I do not know",
       nextUrlAfterOfficerSelection: Paths.WE_MAY_HOLD_THIS_RECORD,
       expectedTemplateIdentifier: "we-may-hold-this-record--generic",
-      isChangeOrderAvailable: false,
+      isChangeOrderAvailable: true,
     },
   ];
 

--- a/test/playwright/state-transitions/your-order-type-british-army-officers.spec.ts
+++ b/test/playwright/state-transitions/your-order-type-british-army-officers.spec.ts
@@ -1,0 +1,83 @@
+import { test } from "@playwright/test";
+import { Paths } from "../lib/constants";
+import {
+  continueFromBeforeYouStart,
+  continueFromHaveYouPreviouslyMadeARequest,
+  continueFromHowWeProcessRequests,
+  continueFromIsServicePersonAlive,
+  continueFromJourneyStart,
+  continueFromProvideAProofOfDeath,
+  continueFromServicePersonDetails,
+  continueFromUploadAProofOfDeath,
+  continueFromWeAreUnlikelyToHoldThisRecord,
+  continueFromWereTheyACommissionedOfficer,
+  continueFromWhatWasTheirDateOfBirth,
+  continueFromWhichMilitaryBranchDidThePersonServeIn,
+  continueFromYouMayWantToCheckAncestry,
+  continueFromYourOrderTypeBritishArmyOfficers,
+} from "../lib/step-functions";
+import { robertHughJones } from "../end-to-end/test-cases/robert-hugh-jones";
+
+test.describe("the 'Request a military service record' form", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto(Paths.JOURNEY_START);
+  });
+
+  test("works as expected", async ({ page }) => {
+    test.setTimeout(120_000); // Increase timeout to 2 minutes for this test because it is end-to-end
+    await continueFromJourneyStart(page);
+    await continueFromHowWeProcessRequests(page);
+    await continueFromBeforeYouStart(page, true);
+    await continueFromYouMayWantToCheckAncestry(page);
+    await continueFromIsServicePersonAlive(
+      page,
+      robertHughJones.isAlive,
+      Paths.WHICH_MILITARY_BRANCH_DID_THE_PERSON_SERVE_IN,
+    );
+    await continueFromWhichMilitaryBranchDidThePersonServeIn(
+      page,
+      robertHughJones.serviceBranch,
+      Paths.WERE_THEY_A_COMMISSIONED_OFFICER,
+    );
+    await continueFromWereTheyACommissionedOfficer(
+      page,
+      "Yes", // Robert Hugh Jones was not a commissioned officer, so we select "Yes" to the question "Were they a commissioned officer?" to reach the "Your order type" page for Commissioned Officers
+      Paths.WE_ARE_UNLIKELY_TO_HOLD_OFFICER_RECORDS__ARMY,
+      "unlikely-to-hold--army-officer-records",
+    );
+    await continueFromWeAreUnlikelyToHoldThisRecord(
+      page,
+      Paths.WE_ARE_UNLIKELY_TO_HOLD_OFFICER_RECORDS__ARMY,
+    );
+    await continueFromWhatWasTheirDateOfBirth(
+      page,
+      robertHughJones.dateOfBirth.day,
+      robertHughJones.dateOfBirth.month,
+      robertHughJones.dateOfBirth.year,
+      Paths.PROVIDE_A_PROOF_OF_DEATH,
+      true,
+      "",
+    );
+    await continueFromProvideAProofOfDeath(
+      page,
+      robertHughJones.hasDeathCertificate,
+      Paths.UPLOAD_A_PROOF_OF_DEATH,
+      "Upload a proof of death",
+    );
+    await continueFromUploadAProofOfDeath(
+      page,
+      ".jpg",
+      1024 * 1024 * 4, //  4MB
+      true,
+      "",
+    );
+    await continueFromServicePersonDetails(page, robertHughJones);
+    await continueFromHaveYouPreviouslyMadeARequest(page, {
+      label: robertHughJones.hasPreviouslyMadeRequest,
+      errorMessage: null,
+      populatedReferenceNumber: null,
+      nextPath: Paths.YOUR_ORDER_TYPE_BRITISH_ARMY_OFFICERS,
+    });
+    await continueFromYourOrderTypeBritishArmyOfficers(page);
+  });
+});

--- a/test/playwright/state-transitions/your-order-type-british-army-officers.spec.ts
+++ b/test/playwright/state-transitions/your-order-type-british-army-officers.spec.ts
@@ -1,6 +1,7 @@
 import { test } from "@playwright/test";
 import { Paths } from "../lib/constants";
 import {
+  clickBackLink,
   continueFromBeforeYouStart,
   continueFromHaveYouPreviouslyMadeARequest,
   continueFromHowWeProcessRequests,
@@ -79,5 +80,8 @@ test.describe("the 'Your order type page for British Army officers' form", () =>
       nextPath: Paths.YOUR_ORDER_TYPE_BRITISH_ARMY_OFFICERS,
     });
     await continueFromYourOrderTypeBritishArmyOfficers(page);
+    // the previous step function results in the user being on "Your contact details"
+    // so we check the back link takes them back to the correct order type variant
+    await clickBackLink(page, Paths.YOUR_ORDER_TYPE_BRITISH_ARMY_OFFICERS);
   });
 });

--- a/test/playwright/state-transitions/your-order-type-other-and-dont-know.spec.ts
+++ b/test/playwright/state-transitions/your-order-type-other-and-dont-know.spec.ts
@@ -1,6 +1,7 @@
 import { test } from "@playwright/test";
 import { Paths } from "../lib/constants";
 import {
+  clickBackLink,
   continueFromBeforeYouStart,
   continueFromHaveYouPreviouslyMadeARequest,
   continueFromHowWeProcessRequests,
@@ -100,6 +101,12 @@ test.describe("the 'Your order type for officers where service branch is 'other'
       page,
     }) => {
       await runFromStartPageToYourOrderTypePage(page, person);
+      // the previous step function results in the user being on "Your contact details"
+      // so we check the back link takes them back to the correct order type variant
+      await clickBackLink(
+        page,
+        Paths.YOUR_ORDER_TYPE_OTHER_AND_DONT_KNOW_OFFICERS,
+      );
     });
   });
 });

--- a/test/playwright/state-transitions/your-order-type-other-and-dont-know.spec.ts
+++ b/test/playwright/state-transitions/your-order-type-other-and-dont-know.spec.ts
@@ -14,70 +14,92 @@ import {
   continueFromWhatWasTheirDateOfBirth,
   continueFromWhichMilitaryBranchDidThePersonServeIn,
   continueFromYouMayWantToCheckAncestry,
-  continueFromYourOrderTypeBritishArmyOfficers,
+  continueFromYourOrderTypeOtherAndDontKnowOfficers,
 } from "../lib/step-functions";
-import { armyOfficer } from "../end-to-end/test-cases/your-order-type-variants/army-officer";
+import { otherOfficer } from "../end-to-end/test-cases/your-order-type-variants/other-officer";
+import { unknownOfficer } from "../end-to-end/test-cases/your-order-type-variants/unknown-officer";
 
-test.describe("the 'Your order type page for British Army officers' form", () => {
+test.describe("the 'Your order type for officers where service branch is 'other' or unknown form", () => {
+  const scenarios = [{ person: otherOfficer }, { person: unknownOfficer }];
+
   test.beforeEach(async ({ page }) => {
     await page.goto(Paths.JOURNEY_START);
   });
 
-  test("works as expected", async ({ page }) => {
-    test.setTimeout(120_000); // Increase timeout to 2 minutes for this test because it is end-to-end
+  async function runFromStartPageToYourOrderTypePage(page, person) {
+    test.setTimeout(120_000); // End-to-end path
+
     await continueFromJourneyStart(page);
     await continueFromHowWeProcessRequests(page);
     await continueFromBeforeYouStart(page, true);
     await continueFromYouMayWantToCheckAncestry(page);
+
     await continueFromIsServicePersonAlive(
       page,
-      armyOfficer.isAlive,
+      person.isAlive,
       Paths.WHICH_MILITARY_BRANCH_DID_THE_PERSON_SERVE_IN,
     );
+
     await continueFromWhichMilitaryBranchDidThePersonServeIn(
       page,
-      armyOfficer.serviceBranch,
+      person.serviceBranch,
       Paths.WERE_THEY_A_COMMISSIONED_OFFICER,
     );
+
     await continueFromWereTheyACommissionedOfficer(
       page,
-      armyOfficer.wasOfficer,
-      Paths.WE_ARE_UNLIKELY_TO_HOLD_OFFICER_RECORDS__ARMY,
-      "unlikely-to-hold--army-officer-records",
+      person.wasOfficer,
+      Paths.WE_ARE_UNLIKELY_TO_HOLD_OFFICER_RECORDS__GENERIC,
+      "we-are-unlikely-to-hold-this-record--generic",
     );
+
     await continueFromWeAreUnlikelyToHoldThisRecord(
       page,
-      Paths.WE_ARE_UNLIKELY_TO_HOLD_OFFICER_RECORDS__ARMY,
+      Paths.WE_ARE_UNLIKELY_TO_HOLD_OFFICER_RECORDS__GENERIC,
     );
+
     await continueFromWhatWasTheirDateOfBirth(
       page,
-      armyOfficer.dateOfBirth.day,
-      armyOfficer.dateOfBirth.month,
-      armyOfficer.dateOfBirth.year,
+      person.dateOfBirth.day,
+      person.dateOfBirth.month,
+      person.dateOfBirth.year,
       Paths.PROVIDE_A_PROOF_OF_DEATH,
       true,
       "",
     );
+
     await continueFromProvideAProofOfDeath(
       page,
-      armyOfficer.hasDeathCertificate,
+      person.hasDeathCertificate,
       Paths.UPLOAD_A_PROOF_OF_DEATH,
       "Upload a proof of death",
     );
+
     await continueFromUploadAProofOfDeath(
       page,
       ".jpg",
-      1024 * 1024 * 4, //  4MB
+      1024 * 1024 * 4,
       true,
       "",
     );
-    await continueFromServicePersonDetails(page, armyOfficer);
+
+    await continueFromServicePersonDetails(page, person);
+
     await continueFromHaveYouPreviouslyMadeARequest(page, {
-      label: armyOfficer.hasPreviouslyMadeRequest,
+      label: person.hasPreviouslyMadeRequest,
       errorMessage: null,
       populatedReferenceNumber: null,
-      nextPath: Paths.YOUR_ORDER_TYPE_BRITISH_ARMY_OFFICERS,
+      nextPath: Paths.YOUR_ORDER_TYPE_OTHER_AND_DONT_KNOW_OFFICERS,
     });
-    await continueFromYourOrderTypeBritishArmyOfficers(page);
+
+    await continueFromYourOrderTypeOtherAndDontKnowOfficers(page);
+  }
+
+  scenarios.forEach(({ person }) => {
+    test(`works as expected when service branch is '${person.serviceBranch}'`, async ({
+      page,
+    }) => {
+      await runFromStartPageToYourOrderTypePage(page, person);
+    });
   });
 });


### PR DESCRIPTION
This pull request introduces new user flows for Commissioned Officer service record requests, specifically for users that have selected British Army, "Other" or "I don't know" as the service branch. 

The key commits are: 

- 2a8ec2aa9bb6425de2d6eb93127020b753585a76 introduces the new British Army Officer order type page
- cf0783237f88315940dedebf99aaad5f9265af10 adds the new order type page where the service branch is stated as "Other" or "I don't know"
- f7f411cb37e642d7653d2062f774629194e235e8 introduces a new `conditionallyAvailableLink()` macro - which we use to manage the presentation of the "Change order" link
- 022f7dee79fb4fb833e16c5d488c11a0030940ca makes "Back" links dynamic on "Your contact details" (because it can now be reached via multiple routes). 

Changes include the addition of new forms, routes, and content to ensure users are correctly guided through the request process and informed about restrictions and costs. 

All changes are also extensively tested with Pytest and Playwright.
