### PR TITLE
FOI-295: Make "Change order" link availability dynamic

### DIFF
--- a/app/lib/derive_if_change_order_is_available.py
+++ b/app/lib/derive_if_change_order_is_available.py
@@ -1,0 +1,44 @@
+"""
+Module for deriving if a user can change their order type.
+
+A user can change their order if:
+1. The service person was NOT an officer, OR
+2. The service person was an officer AND the service branch is RAF
+"""
+
+from typing import Optional
+
+
+def derive_if_change_order_is_available(form_data: Optional[dict]) -> bool:
+    """
+    Determine if a user can change their order type based on form data.
+
+    Args:
+        form_data: Dictionary containing form submission data with keys:
+                  - were_they_a_commissioned_officer: "yes", "no", or "unknown"
+                  - service_branch: Service branch identifier (e.g., "ROYAL_AIR_FORCE")
+
+    Returns:
+        bool: True if the user can change their order, False otherwise.
+              Returns True if:
+              - Service person was not an officer (was "no"), OR
+              - Service person was an officer ("yes") AND service branch is "ROYAL_AIR_FORCE"
+
+              Returns False in all other cases.
+    """
+    if form_data is None:
+        return False
+
+    officer_status = form_data.get("were_they_a_commissioned_officer")
+    service_branch = form_data.get("service_branch")
+
+    # If service person was not an officer, return True
+    if officer_status == "no":
+        return True
+
+    # If service person was an officer AND service branch is RAF, return True
+    if officer_status == "yes" and service_branch == "ROYAL_AIR_FORCE":
+        return True
+
+    # All other cases
+    return False

--- a/app/lib/derive_if_change_order_is_available.py
+++ b/app/lib/derive_if_change_order_is_available.py
@@ -22,6 +22,7 @@ def derive_if_change_order_is_available(form_data: Optional[dict]) -> bool:
         bool: True if the user can change their order, False otherwise.
               Returns True if:
               - Service person was not an officer (was "no"), OR
+              - Service person may have been an officer (was "unknown"), OR
               - Service person was an officer ("yes") AND service branch is "ROYAL_AIR_FORCE"
 
               Returns False in all other cases.
@@ -34,6 +35,10 @@ def derive_if_change_order_is_available(form_data: Optional[dict]) -> bool:
 
     # If service person was not an officer, return True
     if officer_status == "no":
+        return True
+
+    # If officer status is unknown, return True
+    if officer_status == "unknown":
         return True
 
     # If service person was an officer AND service branch is RAF, return True

--- a/app/main/routes/routes.py
+++ b/app/main/routes/routes.py
@@ -9,6 +9,9 @@ from app.lib.decorators.update_dynamic_back_link_mapping import (
 from app.lib.decorators.with_form_prefilled_from_session import (
     with_form_prefilled_from_session,
 )
+from app.lib.derive_if_change_order_is_available import (
+    derive_if_change_order_is_available,
+)
 from app.lib.get_dynamic_back_link_route import get_dynamic_back_link_route
 from app.lib.price_calculations import prepare_order_summary_data
 from app.lib.save_catalogue_reference_to_session import (
@@ -561,6 +564,8 @@ def your_order_summary(form, state_machine):
             url_for("main.start")
         )  # TODO: What should the user see if order summary fails?
 
+    can_change_order = derive_if_change_order_is_available(form_data)
+
     return render_template(
         "main/your-order-summary.html",
         content=load_content(),
@@ -568,6 +573,7 @@ def your_order_summary(form, state_machine):
         form_data=form_data,
         order_summary_data=order_summary_data,
         back_link_route=get_dynamic_back_link_route(key=request.endpoint),
+        can_change_order=can_change_order,
     )
 
 

--- a/app/templates/macros/conditionally-available-link.html
+++ b/app/templates/macros/conditionally-available-link.html
@@ -1,0 +1,7 @@
+{% macro conditionallyAvailableLink(route_name, content, should_render=True) -%}
+  {% if should_render %}
+    <a href="{{ url_for(route_name) }}" class="tna-button tna-button--plain">
+      {{ content }}
+    </a>
+  {% endif %}
+{%- endmacro %}

--- a/app/templates/main/your-order-summary.html
+++ b/app/templates/main/your-order-summary.html
@@ -1,6 +1,7 @@
 {% extends "base.html" %}
 
 {%- from 'macros/order-price.html' import orderPrice %}
+{%- from 'macros/conditionally-available-link.html' import conditionallyAvailableLink %}
 
 {%- set pageTitle = content.pages.your_order_summary.heading | prepare_page_title -%}
 
@@ -48,9 +49,7 @@
           <form action="{{ url_for('main.your_order_summary') }}" method="post" novalidate>
             {{ form.csrf_token }}
             <div class="tna-button-group">
-              <a href="{{ url_for('main.choose_your_order_type') }}" class="tna-button tna-button--plain">
-                {{ content.pages.your_order_summary.change_order_type }}
-              </a>
+              {{ conditionallyAvailableLink('main.choose_your_order_type', content.pages.your_order_summary.change_order_type) }}
               {{ form.submit(params={'classes': 'tna-button--accent'}) }}
             </div>
           </form>

--- a/app/templates/main/your-order-summary.html
+++ b/app/templates/main/your-order-summary.html
@@ -49,7 +49,7 @@
           <form action="{{ url_for('main.your_order_summary') }}" method="post" novalidate>
             {{ form.csrf_token }}
             <div class="tna-button-group">
-              {{ conditionallyAvailableLink('main.choose_your_order_type', content.pages.your_order_summary.change_order_type) }}
+              {{ conditionallyAvailableLink('main.choose_your_order_type', content.pages.your_order_summary.change_order_type, can_change_order) }}
               {{ form.submit(params={'classes': 'tna-button--accent'}) }}
             </div>
           </form>

--- a/test/lib/test_derive_if_change_order_is_available.py
+++ b/test/lib/test_derive_if_change_order_is_available.py
@@ -1,0 +1,81 @@
+"""
+Unit tests for derive_if_change_order_is_available function.
+"""
+
+from app.lib.derive_if_change_order_is_available import (
+    derive_if_change_order_is_available,
+)
+
+
+class TestDeriveIfChangeOrderIsAvailable:
+    """Test suite for derive_if_change_order_is_available function."""
+
+    # Tests for non-officer status
+    def test_returns_true_when_service_person_is_not_an_officer(self):
+        """Test that True is returned when service person is not an officer."""
+        form_data = {
+            "were_they_a_commissioned_officer": "no",
+            "service_branch": "BRITISH_ARMY",
+        }
+        assert derive_if_change_order_is_available(form_data) is True
+
+    def test_returns_true_for_non_officer_regardless_of_service_branch(self):
+        """Test that True is returned for non-officer regardless of service branch."""
+        service_branches = [
+            "ROYAL_NAVY",
+            "BRITISH_ARMY",
+            "ROYAL_AIR_FORCE",
+            "HOME_GUARD",
+            "OTHER",
+            "UNKNOWN",
+        ]
+        for branch in service_branches:
+            form_data = {
+                "were_they_a_commissioned_officer": "no",
+                "service_branch": branch,
+            }
+            assert derive_if_change_order_is_available(form_data) is True
+
+    # Tests for officer status with RAF
+    def test_returns_true_when_officer_and_service_branch_is_raf(self):
+        """Test that True is returned when service person is an officer in RAF."""
+        form_data = {
+            "were_they_a_commissioned_officer": "yes",
+            "service_branch": "ROYAL_AIR_FORCE",
+        }
+        assert derive_if_change_order_is_available(form_data) is True
+
+    # Tests for officer status without RAF
+    def test_returns_false_when_officer_and_service_branch_is_not_raf(self):
+        """Test that False is returned when service person is an officer but not in RAF."""
+        service_branches = [
+            "ROYAL_NAVY",
+            "BRITISH_ARMY",
+            "HOME_GUARD",
+            "OTHER",
+            "UNKNOWN",
+        ]
+        for branch in service_branches:
+            form_data = {
+                "were_they_a_commissioned_officer": "yes",
+                "service_branch": branch,
+            }
+            assert derive_if_change_order_is_available(form_data) is False
+
+    # Tests for unknown officer status
+    def test_returns_false_when_officer_status_is_unknown(self):
+        """Test that False is returned when officer status is unknown."""
+        service_branches = [
+            "ROYAL_NAVY",
+            "BRITISH_ARMY",
+            "ROYAL_AIR_FORCE",
+            "HOME_GUARD",
+            "OTHER",
+            "UNKNOWN",
+        ]
+        for branch in service_branches:
+            form_data = {
+                "were_they_a_commissioned_officer": "unknown",
+                "service_branch": branch,
+            }
+            assert derive_if_change_order_is_available(form_data) is False

--- a/test/lib/test_derive_if_change_order_is_available.py
+++ b/test/lib/test_derive_if_change_order_is_available.py
@@ -78,4 +78,4 @@ class TestDeriveIfChangeOrderIsAvailable:
                 "were_they_a_commissioned_officer": "unknown",
                 "service_branch": branch,
             }
-            assert derive_if_change_order_is_available(form_data) is False
+            assert derive_if_change_order_is_available(form_data) is True

--- a/test/lib/test_template_macro_conditionally_available_link.py
+++ b/test/lib/test_template_macro_conditionally_available_link.py
@@ -1,0 +1,64 @@
+import pytest
+from flask import url_for
+from werkzeug.routing import BuildError
+
+from app import create_app
+
+
+@pytest.fixture
+def app():
+    return create_app("config.Test")
+
+
+def test_conditionally_available_link_renders_route_href_text_and_classes(app):
+    with app.test_request_context():
+        macro_template = app.jinja_env.get_template(
+            "macros/conditionally-available-link.html"
+        )
+        rendered = macro_template.module.conditionallyAvailableLink(
+            "main.choose_your_order_type", "Change order type", True
+        )
+
+        expected_href = url_for("main.choose_your_order_type")
+
+    assert f'href="{expected_href}"' in rendered
+    assert "Change order type" in rendered
+
+
+def test_conditionally_available_link_raises_for_invalid_route_name(app):
+    with app.test_request_context():
+        macro_template = app.jinja_env.get_template(
+            "macros/conditionally-available-link.html"
+        )
+
+        with pytest.raises(BuildError):
+            macro_template.module.conditionallyAvailableLink(
+                "main.not_a_real_route", "Broken", True
+            )
+
+
+def test_conditionally_available_link_renders_nothing_when_flag_is_false(app):
+    with app.test_request_context():
+        macro_template = app.jinja_env.get_template(
+            "macros/conditionally-available-link.html"
+        )
+        rendered = macro_template.module.conditionallyAvailableLink(
+            "main.choose_your_order_type", "Change order type", False
+        )
+
+    assert rendered.strip() == ""
+
+
+def test_conditionally_available_link_renders_when_should_render_omitted(app):
+    with app.test_request_context():
+        macro_template = app.jinja_env.get_template(
+            "macros/conditionally-available-link.html"
+        )
+        rendered = macro_template.module.conditionallyAvailableLink(
+            "main.choose_your_order_type", "Change order type"
+        )
+
+        expected_href = url_for("main.choose_your_order_type")
+
+    assert f'href="{expected_href}"' in rendered
+    assert "Change order type" in rendered

--- a/test/lib/test_template_macro_conditionally_available_link.py
+++ b/test/lib/test_template_macro_conditionally_available_link.py
@@ -16,13 +16,13 @@ def test_conditionally_available_link_renders_route_href_text_and_classes(app):
             "macros/conditionally-available-link.html"
         )
         rendered = macro_template.module.conditionallyAvailableLink(
-            "main.choose_your_order_type", "Change order type", True
+            "main.choose_your_order_type", "Change order", True
         )
 
         expected_href = url_for("main.choose_your_order_type")
 
     assert f'href="{expected_href}"' in rendered
-    assert "Change order type" in rendered
+    assert "Change order" in rendered
 
 
 def test_conditionally_available_link_raises_for_invalid_route_name(app):
@@ -43,7 +43,7 @@ def test_conditionally_available_link_renders_nothing_when_flag_is_false(app):
             "macros/conditionally-available-link.html"
         )
         rendered = macro_template.module.conditionallyAvailableLink(
-            "main.choose_your_order_type", "Change order type", False
+            "main.choose_your_order_type", "Change order", False
         )
 
     assert rendered.strip() == ""
@@ -55,10 +55,10 @@ def test_conditionally_available_link_renders_when_should_render_omitted(app):
             "macros/conditionally-available-link.html"
         )
         rendered = macro_template.module.conditionallyAvailableLink(
-            "main.choose_your_order_type", "Change order type"
+            "main.choose_your_order_type", "Change order"
         )
 
         expected_href = url_for("main.choose_your_order_type")
 
     assert f'href="{expected_href}"' in rendered
-    assert "Change order type" in rendered
+    assert "Change order" in rendered

--- a/test/playwright/lib/step-functions.ts
+++ b/test/playwright/lib/step-functions.ts
@@ -549,13 +549,17 @@ export async function continueFromYourOrderTypeOtherAndDontKnowOfficers(page) {
 export async function continueToChooseYourOrderTypeFromJourneyStart(
   page,
   {
-    isAlive,
+    isAlive = "No",
     serviceBranch,
     wasOfficer,
+    nextUrlAfterOfficerSelection = Paths.WE_MAY_HOLD_THIS_RECORD,
+    expectedTemplateIdentifier = "we-may-hold-this-record--generic",
   }: {
-    isAlive: string;
+    isAlive?: string;
     serviceBranch: string;
     wasOfficer: string;
+    nextUrlAfterOfficerSelection?: string;
+    expectedTemplateIdentifier?: string;
   },
 ) {
   await page.goto(Paths.JOURNEY_START);
@@ -576,8 +580,8 @@ export async function continueToChooseYourOrderTypeFromJourneyStart(
   await continueFromWereTheyACommissionedOfficer(
     page,
     wasOfficer,
-    Paths.WE_MAY_HOLD_THIS_RECORD,
-    "we-may-hold-this-record--generic",
+    nextUrlAfterOfficerSelection,
+    expectedTemplateIdentifier,
   );
 
   await page.goto(Paths.CHOOSE_YOUR_ORDER_TYPE);

--- a/test/playwright/lib/step-functions.ts
+++ b/test/playwright/lib/step-functions.ts
@@ -541,3 +541,44 @@ export async function continueFromYourOrderTypeOtherAndDontKnowOfficers(page) {
     .click();
   await expect(page).toHaveURL(Paths.YOUR_CONTACT_DETAILS);
 }
+
+/**
+ * Builds the journey state needed for order-summary tests, then navigates
+ * directly to Choose your order type once the required prior answers are set.
+ */
+export async function continueToChooseYourOrderTypeFromJourneyStart(
+  page,
+  {
+    isAlive,
+    serviceBranch,
+    wasOfficer,
+  }: {
+    isAlive: string;
+    serviceBranch: string;
+    wasOfficer: string;
+  },
+) {
+  await page.goto(Paths.JOURNEY_START);
+  await continueFromJourneyStart(page);
+  await continueFromHowWeProcessRequests(page);
+  await continueFromBeforeYouStart(page, true);
+  await continueFromYouMayWantToCheckAncestry(page);
+  await continueFromIsServicePersonAlive(
+    page,
+    isAlive,
+    Paths.WHICH_MILITARY_BRANCH_DID_THE_PERSON_SERVE_IN,
+  );
+  await continueFromWhichMilitaryBranchDidThePersonServeIn(
+    page,
+    serviceBranch,
+    Paths.WERE_THEY_A_COMMISSIONED_OFFICER,
+  );
+  await continueFromWereTheyACommissionedOfficer(
+    page,
+    wasOfficer,
+    Paths.WE_MAY_HOLD_THIS_RECORD,
+    "we-may-hold-this-record--generic",
+  );
+
+  await page.goto(Paths.CHOOSE_YOUR_ORDER_TYPE);
+}

--- a/test/playwright/state-transitions/your-order-summary.spec.ts
+++ b/test/playwright/state-transitions/your-order-summary.spec.ts
@@ -10,6 +10,7 @@ import {
 
 test.describe("Routes to 'Your order summary'", () => {
   test.beforeEach(async ({ page }) => {
+    test.setTimeout(120_000); // Increase timeout to 2 minutes for this test because it is end-to-end
     await continueToChooseYourOrderTypeFromJourneyStart(page, {
       isAlive: "No",
       serviceBranch: "British Army",
@@ -134,6 +135,72 @@ test.describe("Routes to 'Your order summary'", () => {
       await continueFromYourContactDetails(page, personMakingRequest);
       await page.getByRole("link", { name: "Change order" }).click();
       await expect(page).toHaveURL(Paths.CHOOSE_YOUR_ORDER_TYPE);
+    });
+  }
+});
+
+test.describe("'Change order' availability rules on 'Your order summary'", () => {
+  // These are just a sample of combinations - the full range of combinations is
+  // covered by unit tests.
+  const changeOrderAvailabilityScenarios = [
+    {
+      description: "when the service person was not an officer",
+      serviceBranch: "British Army",
+      wasOfficer: "No",
+      nextUrlAfterOfficerSelection: Paths.WE_MAY_HOLD_THIS_RECORD,
+      expectedTemplateIdentifier: "we-may-hold-this-record--generic",
+      isChangeOrderAvailable: true,
+    },
+    {
+      description:
+        "when the service person was an officer in the Royal Air Force",
+      serviceBranch: "Royal Air Force",
+      wasOfficer: "Yes",
+      nextUrlAfterOfficerSelection:
+        Paths.WE_ARE_UNLIKELY_TO_HOLD_OFFICER_RECORDS__RAF,
+      expectedTemplateIdentifier: "unlikely-to-hold--raf-officer-records",
+      isChangeOrderAvailable: true,
+    },
+    {
+      description: "when the service person was an officer in a non-RAF branch",
+      serviceBranch: "British Army",
+      wasOfficer: "Yes",
+      nextUrlAfterOfficerSelection:
+        Paths.WE_ARE_UNLIKELY_TO_HOLD_OFFICER_RECORDS__ARMY,
+      expectedTemplateIdentifier: "unlikely-to-hold--army-officer-records",
+      isChangeOrderAvailable: false,
+    },
+    {
+      description: "when officer status is unknown",
+      serviceBranch: "Royal Air Force",
+      wasOfficer: "I do not know",
+      nextUrlAfterOfficerSelection: Paths.WE_MAY_HOLD_THIS_RECORD,
+      expectedTemplateIdentifier: "we-may-hold-this-record--generic",
+      isChangeOrderAvailable: false,
+    },
+  ];
+
+  for (const scenario of changeOrderAvailabilityScenarios) {
+    test(`the 'Change order' link is ${scenario.isChangeOrderAvailable ? "" : "not "}shown ${scenario.description}`, async ({
+      page,
+    }) => {
+      await continueToChooseYourOrderTypeFromJourneyStart(page, scenario);
+      await continueFromChooseYourOrderType(page, "Choose standard");
+      await continueFromYourContactDetails(page, {
+        firstName: "Francis",
+        lastName: "Palgrave",
+        emailAddress: "test@example.com",
+      });
+
+      const changeOrderLink = page.getByRole("link", { name: "Change order" });
+
+      if (scenario.isChangeOrderAvailable) {
+        await expect(changeOrderLink).toBeVisible();
+        await changeOrderLink.click();
+        await expect(page).toHaveURL(Paths.CHOOSE_YOUR_ORDER_TYPE);
+      } else {
+        await expect(changeOrderLink).toHaveCount(0);
+      }
     });
   }
 });

--- a/test/playwright/state-transitions/your-order-summary.spec.ts
+++ b/test/playwright/state-transitions/your-order-summary.spec.ts
@@ -5,12 +5,16 @@ import {
   continueFromChooseYourOrderType,
   continueFromYourContactDetails,
   continueFromYourPostalAddress,
+  continueToChooseYourOrderTypeFromJourneyStart,
 } from "../lib/step-functions";
 
 test.describe("Routes to 'Your order summary'", () => {
   test.beforeEach(async ({ page }) => {
-    await page.goto(Paths.JOURNEY_START);
-    await page.goto(Paths.CHOOSE_YOUR_ORDER_TYPE);
+    await continueToChooseYourOrderTypeFromJourneyStart(page, {
+      isAlive: "No",
+      serviceBranch: "British Army",
+      wasOfficer: "No",
+    });
   });
 
   const providedByPostTests = [

--- a/test/playwright/state-transitions/your-order-summary.spec.ts
+++ b/test/playwright/state-transitions/your-order-summary.spec.ts
@@ -176,7 +176,7 @@ test.describe("'Change order' availability rules on 'Your order summary'", () =>
       wasOfficer: "I do not know",
       nextUrlAfterOfficerSelection: Paths.WE_MAY_HOLD_THIS_RECORD,
       expectedTemplateIdentifier: "we-may-hold-this-record--generic",
-      isChangeOrderAvailable: false,
+      isChangeOrderAvailable: true,
     },
   ];
 


### PR DESCRIPTION
## Overview

This pull request implements and tests new business logic to control when the "Change order" link is shown on the "Your order summary" page. The business logic is based on the user's answers to "Was the service person an officer?" and service branch. The change:

- [x] Adds `derive_if_change_order_is_available` function to encapsulate the rules for when a user _can_ change their order type.
- [x] Integrates the new function into the `your_order_summary` route in `routes.py`, passing the result as `can_change_order` to the template.
- [x] Adds a reusable Jinja macro `conditionallyAvailableLink` for rendering links conditionally, and updated the "Change order" link in `your-order-summary.html` to use this macro, so it only appears when allowed by the new logic

**Testing:**

* Added comprehensive unit tests for `derive_if_change_order_is_available` covering all combinations of officer status and service branch.
* Added unit tests for the new macro to ensure correct rendering behavior.
* Refactored Playwright end-to-end tests to build up the correct journey state and added new scenarios to verify that the "Change order" link is shown or hidden as appropriate for different user answers