### PR TITLE
FOI-296: Make back links dynamic for order type variants

### DIFF
--- a/app/main/routes/routes.py
+++ b/app/main/routes/routes.py
@@ -242,6 +242,7 @@ def we_do_not_have_royal_navy_service_records(form, state_machine):
 @update_dynamic_back_link_mapping(
     mappings={
         MultiPageFormRoutes.WHAT_WAS_THEIR_DATE_OF_BIRTH: MultiPageFormRoutes.WE_ARE_UNLIKELY_TO_HOLD_OFFICER_RECORDS__ARMY,
+        MultiPageFormRoutes.YOUR_CONTACT_DETAILS: MultiPageFormRoutes.YOUR_ORDER_TYPE_BRITISH_ARMY_OFFICER,
     }
 )
 @with_state_machine
@@ -287,6 +288,7 @@ def we_are_unlikely_to_hold_officer_records__raf(form, state_machine):
 @update_dynamic_back_link_mapping(
     mappings={
         MultiPageFormRoutes.WHAT_WAS_THEIR_DATE_OF_BIRTH: MultiPageFormRoutes.WE_ARE_UNLIKELY_TO_HOLD_OFFICER_RECORDS__GENERIC,
+        MultiPageFormRoutes.YOUR_CONTACT_DETAILS: MultiPageFormRoutes.YOUR_ORDER_TYPE_OTHER_AND_DONT_KNOW_OFFICER,
     }
 )
 @with_form_prefilled_from_session(WeAreUnlikelyToHoldThisRecord)
@@ -462,7 +464,10 @@ def your_contact_details(form, state_machine):
         state_machine.continue_from_your_contact_details_form(form)
         return redirect(url_for(state_machine.route_for_current_state))
     return render_template(
-        "main/your-contact-details.html", form=form, content=load_content()
+        "main/your-contact-details.html",
+        form=form,
+        content=load_content(),
+        back_link_route=get_dynamic_back_link_route(key=request.endpoint),
     )
 
 
@@ -507,6 +512,11 @@ def what_is_your_address(form, state_machine):
 
 
 @bp.route("/choose-your-order-type/", methods=["GET", "POST"])
+@update_dynamic_back_link_mapping(
+    mappings={
+        MultiPageFormRoutes.YOUR_CONTACT_DETAILS: MultiPageFormRoutes.CHOOSE_YOUR_ORDER_TYPE,
+    }
+)
 @with_state_machine
 def choose_your_order_type(state_machine):
     form = ChooseYourOrderType()

--- a/app/templates/main/your-contact-details.html
+++ b/app/templates/main/your-contact-details.html
@@ -3,7 +3,7 @@
 {%- set pageTitle = content.pages.your_contact_details.heading | prepare_page_title -%}
 
 {% block beforeContent %}
-  {{ backLink(url_for('main.choose_your_order_type')) }}
+  {{ backLink(url_for(back_link_route)) }}
 {% endblock beforeContent %}
 
 {% block content %}

--- a/test/playwright/state-transitions/your-order-type-british-army-officers.spec.ts
+++ b/test/playwright/state-transitions/your-order-type-british-army-officers.spec.ts
@@ -1,6 +1,7 @@
 import { test } from "@playwright/test";
 import { Paths } from "../lib/constants";
 import {
+  clickBackLink,
   continueFromBeforeYouStart,
   continueFromHaveYouPreviouslyMadeARequest,
   continueFromHowWeProcessRequests,
@@ -79,5 +80,8 @@ test.describe("the 'Your order type page for British Army officers' form", () =>
       nextPath: Paths.YOUR_ORDER_TYPE_BRITISH_ARMY_OFFICERS,
     });
     await continueFromYourOrderTypeBritishArmyOfficers(page);
+    // the previous step function results in the user being on "Your contact details"
+    // so we check the back link takes them back to the correct order type variant
+    await clickBackLink(page, Paths.YOUR_ORDER_TYPE_BRITISH_ARMY_OFFICERS);
   });
 });

--- a/test/playwright/state-transitions/your-order-type-other-and-dont-know.spec.ts
+++ b/test/playwright/state-transitions/your-order-type-other-and-dont-know.spec.ts
@@ -1,6 +1,7 @@
 import { test } from "@playwright/test";
 import { Paths } from "../lib/constants";
 import {
+  clickBackLink,
   continueFromBeforeYouStart,
   continueFromHaveYouPreviouslyMadeARequest,
   continueFromHowWeProcessRequests,
@@ -100,6 +101,12 @@ test.describe("the 'Your order type for officers where service branch is 'other'
       page,
     }) => {
       await runFromStartPageToYourOrderTypePage(page, person);
+      // the previous step function results in the user being on "Your contact details"
+      // so we check the back link takes them back to the correct order type variant
+      await clickBackLink(
+        page,
+        Paths.YOUR_ORDER_TYPE_OTHER_AND_DONT_KNOW_OFFICERS,
+      );
     });
   });
 });


### PR DESCRIPTION
Changes to the journey mean that "Your contact details" can now be reached via three different order type pages, depending on which options had been selected during their journey:

1. The variant for Officers where service branch is Army
2. The variant for Officers where service branch is "Other" or "I don't know"
3. The original "Choose your order type" page

This PR therefore makes the "Back" link on "Your contact details" dynamic using the existing appraoch we have adopted for this service and updates Playwright tests for each journey to include verification of "Back" link behaviour.