### PR TITLE
Fix: Handle `None` input in `prepare_order_summary_data` function

### DIFF
--- a/app/lib/price_calculations.py
+++ b/app/lib/price_calculations.py
@@ -77,6 +77,10 @@ def calculate_amount_based_on_form_data(form_data: dict) -> int:
 
 
 def prepare_order_summary_data(form_data: dict) -> dict:
+    if not form_data:
+        current_app.logger.error("prepare_order_summary_data called with no form data")
+        return None
+
     processing_option = form_data.get("processing_option", "standard")
     delivery_type = get_delivery_type(form_data)
 

--- a/test/lib/test_price_calculations.py
+++ b/test/lib/test_price_calculations.py
@@ -242,6 +242,13 @@ def test_calculate_amount_when_delivery_fee_api_fails(app_context):
             calculate_amount_based_on_form_data(form_data)
 
 
+def test_prepare_order_summary_data_when_form_data_is_none(app_context):
+    """Test order summary preparation returns None when form data is None."""
+    result = prepare_order_summary_data(None)
+
+    assert result is None
+
+
 def test_prepare_order_summary_data_when_api_fails(app_context):
     """Test order summary preparation when delivery fee API fails."""
     form_data = {


### PR DESCRIPTION
Sentry has highlighted an issue with `prepare_order_summary_data()`, specifically that: 

```
'NoneType' object has no attribute 'get'
```

This commit fixes that issue and updates associated tests to verify expected behaviour. 