### PR TITLE
FOI-304: Fix prepare_order_summary_data

### DIFF
--- a/app/lib/price_calculations.py
+++ b/app/lib/price_calculations.py
@@ -77,6 +77,10 @@ def calculate_amount_based_on_form_data(form_data: dict) -> int:
 
 
 def prepare_order_summary_data(form_data: dict) -> dict:
+    if not form_data:
+        current_app.logger.error("prepare_order_summary_data called with no form data")
+        return None
+
     processing_option = form_data.get("processing_option", "standard")
     delivery_type = get_delivery_type(form_data)
 

--- a/test/lib/test_price_calculations.py
+++ b/test/lib/test_price_calculations.py
@@ -242,6 +242,13 @@ def test_calculate_amount_when_delivery_fee_api_fails(app_context):
             calculate_amount_based_on_form_data(form_data)
 
 
+def test_prepare_order_summary_data_when_form_data_is_none(app_context):
+    """Test order summary preparation returns None when form data is missing."""
+    result = prepare_order_summary_data(None)
+
+    assert result is None
+
+
 def test_prepare_order_summary_data_when_api_fails(app_context):
     """Test order summary preparation when delivery fee API fails."""
     form_data = {

--- a/test/main/test_payment_routes.py
+++ b/test/main/test_payment_routes.py
@@ -25,7 +25,10 @@ class DummyPayment:
 
 @pytest.fixture(scope="module")
 def app():
-    return create_app("config.Test")
+    app = create_app("config.Test")
+    # We need to disable CSRF protection for those tests that POST to routes which use form.validate_on_submit()
+    app.config["WTF_CSRF_ENABLED"] = False
+    return app
 
 
 @pytest.fixture()
@@ -204,3 +207,71 @@ def test_handle_gov_uk_pay_response_unsuccessful_payment_does_not_clear_session(
     mock_fetch.assert_called_once_with("service_record", "TEST-ID")
     mock_get_payment_data.assert_called_once_with("GOV-UK-PAY-ID")
     mock_process_service_record_payment.assert_not_called()
+
+
+def test_your_order_summary_redirects_to_start_when_form_data_missing(client, app):
+    """Test that your order summary redirects to service start page when form data is missing from session."""
+    with client.session_transaction() as sess:
+        sess["entered_through_index_page"] = True
+
+    rv = client.get(f"{app.config.get('SERVICE_URL_PREFIX')}/your-order-summary/")
+
+    assert rv.status_code == 302
+    assert rv.location.endswith(f"{app.config.get('SERVICE_URL_PREFIX')}/")
+
+
+def test_your_order_summary_renders_when_form_data_present(client, app):
+    """Test that "Your order summary" renders when form data is present in the session."""
+    with client.session_transaction() as sess:
+        sess["entered_through_index_page"] = True
+        sess["form_data"] = {
+            "processing_option": "standard",
+            "does_not_have_email": False,
+        }
+
+    rv = client.get(f"{app.config.get('SERVICE_URL_PREFIX')}/your-order-summary/")
+
+    assert rv.status_code == 200
+    assert "Your order summary" in rv.text
+
+
+def test_payment_incomplete_continue_redirects_to_order_summary_when_form_data_present(
+    client, app
+):
+    """Test that payment incomplete redirects to order summary when it is requested."""
+    with client.session_transaction() as sess:
+        sess["entered_through_index_page"] = True
+        sess["form_data"] = {
+            "processing_option": "standard",
+            "does_not_have_email": False,
+        }
+
+    rv = client.post(
+        f"{app.config.get('SERVICE_URL_PREFIX')}/payment-incomplete/",
+        data={"submit": "1"},
+    )
+
+    assert rv.status_code == 302
+    assert rv.location.endswith(
+        f"{app.config.get('SERVICE_URL_PREFIX')}/your-order-summary/"
+    )
+
+
+def test_payment_incomplete_continue_redirects_to_order_summary_when_form_data_missing(
+    client, app
+):
+    """
+    Test that payment incomplete ultimately redirects to order summary even when form data is missing.
+    Note: in actuality, this redirect is via the guarded "Your order summary" route (hence the `follow_redirects`)
+    """
+    with client.session_transaction() as sess:
+        sess["entered_through_index_page"] = True
+
+    rv = client.post(
+        f"{app.config.get('SERVICE_URL_PREFIX')}/payment-incomplete/",
+        data={"submit": "1"},
+        follow_redirects=True,
+    )
+
+    assert rv.status_code == 200
+    assert app.config.get("SERVICE_URL_PREFIX") in rv.request.path

--- a/test/playwright/state-transitions/payment-incomplete.spec.ts
+++ b/test/playwright/state-transitions/payment-incomplete.spec.ts
@@ -1,6 +1,10 @@
-import { test } from "@playwright/test";
+import { expect, test } from "@playwright/test";
 import { Paths } from "../lib/constants";
-import { continueFromPaymentIncomplete } from "../lib/step-functions";
+import {
+  continueFromChooseYourOrderType,
+  continueFromPaymentIncomplete,
+  continueFromYourContactDetails,
+} from "../lib/step-functions";
 
 test.describe("the 'Problem processing payment' form", () => {
   test.beforeEach(async ({ page }) => {
@@ -8,9 +12,37 @@ test.describe("the 'Problem processing payment' form", () => {
     await page.goto(Paths.PAYMENT_INCOMPLETE);
   });
 
-  test.describe("works as expected", () => {
-    test("when continuing to 'Your order summary'", async ({ page }) => {
-      await continueFromPaymentIncomplete(page);
+  test.describe("works as expected when attempting to continue to 'Your order summary'", () => {
+    test.describe("'Your order summary' can be reached", () => {
+      test("when the steps necessary to populate relevant session values have been followed", async ({
+        page,
+      }) => {
+        await page.goto(Paths.CHOOSE_YOUR_ORDER_TYPE);
+        await continueFromChooseYourOrderType(page, "Choose standard");
+        await continueFromYourContactDetails(page, {
+          firstName: "Francis",
+          lastName: "Palgrave",
+          emailAddress: "test@example.com",
+        });
+        await page.goto(Paths.PAYMENT_INCOMPLETE);
+
+        await continueFromPaymentIncomplete(page);
+      });
+    });
+
+    test.describe("'Your order summary' cannot be reached", () => {
+      test("when the steps necessary to populate relevant session values have NOT been followed", async ({
+        page,
+      }) => {
+        await expect(page).toHaveURL(Paths.PAYMENT_INCOMPLETE);
+        await expect(page.locator("h1")).toHaveText(
+          /Sorry, there was a problem processing your payment/,
+        );
+        await page
+          .getByRole("button", { name: "Go back to try the payment again" })
+          .click();
+        await expect(page).toHaveURL(Paths.JOURNEY_START);
+      });
     });
   });
 });


### PR DESCRIPTION
Sentry identified that `prepare_order_summary_data` does not properly handle scenarios where `form_data` is missing. See the associated Jira ticket for details. 

This PR:

1. Adds handling along with an associated test
2. Updates Playwright tests to cover both scenarios (both direct access and the expected route)
3. Expands `test_payment_routes.py` to handle all these scenarios