### PR TITLE
Send commissioned officer status to Dynamics

### DIFF
--- a/app/lib/db/models.py
+++ b/app/lib/db/models.py
@@ -38,6 +38,7 @@ class ServiceRecordRequest(db.Model):
     requester_postcode = db.Column(db.String(32), nullable=True)
     requester_town_city = db.Column(db.String(128))
     service_branch = db.Column(db.String(64))
+    were_they_a_commissioned_officer = db.Column(db.String(32), nullable=True)
     service_number = db.Column(db.String(64), nullable=True)
     proof_of_death = db.Column(db.String(64), nullable=True)
     gov_uk_payment_id = db.Column(db.String(64), nullable=True, unique=True)

--- a/app/lib/dynamics_handler.py
+++ b/app/lib/dynamics_handler.py
@@ -33,6 +33,7 @@ DYNAMICS_REQUEST_FIELD_MAP = [
     ("date_of_death", "date_of_death"),
     ("mod_barcode_number", "mod_reference"),
     ("service_branch", "service_branch"),
+    ("commissioned_officer", "were_they_a_commissioned_officer"),
     ("died_in_service", "died_in_service"),
     ("prior_contact_reference", "case_reference_number"),
     ("payment_date", "payment_date"),

--- a/test/main/test_database.py
+++ b/test/main/test_database.py
@@ -8,6 +8,7 @@ from app.lib.db.db_handler import (
     add_service_record_request,
     delete_service_record_request,
     get_service_record_request,
+    transform_form_data_to_record,
 )
 from app.lib.db.models import db
 
@@ -44,6 +45,7 @@ def test_add_service_record_request(session):
             "requester_country": "United Kingdom",
             "requester_contact_preference": "email",
             "service_branch": "british_army",
+            "were_they_a_commissioned_officer": "yes",
             "record_hash": "dummyhashvalue",
             "gov_uk_payment_id": "testpaymentid123",
         }
@@ -51,6 +53,19 @@ def test_add_service_record_request(session):
     assert record is not None
     assert record.forenames == "John"
     assert record.requester_email == "john.doe@email.com"
+    assert record.were_they_a_commissioned_officer == "yes"
+
+
+def test_transform_form_data_to_record_normalises_commissioned_officer_status():
+    transformed = transform_form_data_to_record(
+        {
+            "service_branch": "BRITISH_ARMY",
+            "were_they_a_commissioned_officer": "unknown",
+        }
+    )
+
+    assert transformed["service_branch"] == "British Army"
+    assert transformed["were_they_a_commissioned_officer"] == "unknown"
 
 
 def test_get_service_record_request(session):

--- a/test/main/test_dynamics_handler.py
+++ b/test/main/test_dynamics_handler.py
@@ -4,8 +4,12 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from app import create_app
-from app.lib.db.models import DynamicsPayment
-from app.lib.dynamics_handler import send_payment_to_mod_copying_app, subject_status
+from app.lib.db.models import DynamicsPayment, ServiceRecordRequest
+from app.lib.dynamics_handler import (
+    generate_tagged_request,
+    send_payment_to_mod_copying_app,
+    subject_status,
+)
 
 
 class DummyRecord:
@@ -51,6 +55,25 @@ def test_no_evidence_sets_FOICDN_full(context):
     dob = f"20 August {recent_year}"
     r = DummyRecord(dob, None, "full")
     assert subject_status(r) == "? FOI DIRECT MOD FOICDN2"
+
+
+def test_generate_tagged_request_includes_commissioned_officer_status(context):
+    record = ServiceRecordRequest(
+        requester_first_name="Jane",
+        requester_last_name="Doe",
+        requester_email="jane@example.com",
+        requester_address1="1 Test Street",
+        requester_town_city="London",
+        requester_country="United Kingdom",
+        forenames="John",
+        last_name="Smith",
+        date_of_birth="01 January 1950",
+        were_they_a_commissioned_officer="unknown",
+    )
+
+    tagged_request = generate_tagged_request(record)
+
+    assert "<commissioned_officer>unknown</commissioned_officer>" in tagged_request
 
 
 @patch("app.lib.dynamics_handler.requests.post")


### PR DESCRIPTION
Stores `were_they_a_commissioned_officer` in DB, and adds it to the tagged Dynamics data