### PR TITLE
Minimum package age configs

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+min-release-age=7

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,3 +44,6 @@ include = '\.pyi?$'
 testpaths = [
     "test",
 ]
+
+[solver]
+min-release-age = 7


### PR DESCRIPTION
Adds `.npmrc` file and adds `min-release-age = 7` to `pyproject.toml`

Per: https://nationalarchivesuk.slack.com/archives/C027G6UR8N4/p1780908130488819