### PR TITLE
Add meta description

### DIFF
--- a/app/content/content.yaml
+++ b/app/content/content.yaml
@@ -1,5 +1,6 @@
 app:
   title: Request a military service record
+  meta_description: Use this service to make a request to The National Archives to search for a military service record for someone who served in the British Armed Forces after 1918 and who was born before 1940.
 pages:
   all:
     phase_banner:

--- a/app/templates/main/request-a-military-service-record.html
+++ b/app/templates/main/request-a-military-service-record.html
@@ -2,6 +2,11 @@
 
 {%- set pageTitle = content.app.title -%}
 
+{% block head %}
+  {{ super() }}
+  <meta name="description" content="{{ content.app.meta_description }}">
+{% endblock head %}
+
 {% block beforeContent %}
   {{ modFoiBreadcrumbs({'breadcrumbItems': breadcrumbItems, 'hasAccentBackground': true}) }}
 {% endblock beforeContent %}

--- a/test/playwright/state-transitions/request-a-military-service-record.spec.ts
+++ b/test/playwright/state-transitions/request-a-military-service-record.spec.ts
@@ -12,6 +12,13 @@ test.describe("the 'Request a military service record' form", () => {
     await page.goto(Paths.JOURNEY_START);
   });
 
+  test("has the <meta> description", async ({ page }) => {
+    const metaDescriptionElementCount = await page
+      .locator('head > meta[name="description"]')
+      .count();
+    test.expect(metaDescriptionElementCount).toBe(1);
+  });
+
   test("has the correct links", async ({ page }) => {
     await checkInternalLink(
       page,


### PR DESCRIPTION
Because in-journey routes are protected, the only place we need this is on the service start page.

I've also added a Playwright test to confirm its presence.