### PR TITLE
Remove invitation to participate in research

### DIFF
--- a/app/constants.py
+++ b/app/constants.py
@@ -103,7 +103,6 @@ class ExternalLinks:
     INDIAN_ARMY_PERSONNEL_RESEARCH_GUIDE = "https://www.nationalarchives.gov.uk/help-with-your-research/research-guides/indian-army-personnel/"
     BRITISH_ARMY_FIRST_WORLD_WAR_RESEARCH_GUIDE = "https://www.nationalarchives.gov.uk/help-with-your-research/research-guides/british-army-soldiers-of-the-first-world-war/"
     CONTACT_US = "https://www.nationalarchives.gov.uk/contact-us/"
-    OFFICER_ENDPOINT_SURVEY = "https://www.smartsurvey.co.uk/s/1KKGX5/"
 
 
 FALLBACK_COUNTRY_CHOICES = [

--- a/app/content/content.yaml
+++ b/app/content/content.yaml
@@ -255,11 +255,6 @@ pages:
         If you have not done so already, we recommend you check with the Ministry of Defence first.
       - |
         We anticipate holding most Royal Air Force Commissioned Officer records by February 2027.
-    invitation_to_participate_in_research:
-      heading: Register to take part in a research session (opens in new tab)
-      body:
-        We are looking for people who are requesting records for Commissioned Officers.
-        Help us develop this part of the service and receive a voucher for your time.
     call_to_action: Request from the Ministry of Defence
   we_are_unlikely_to_hold_officer_records__army:
     heading: We are unlikely to hold this record yet
@@ -272,11 +267,6 @@ pages:
     list:
       - Grenadier Guards
       - Welsh Guards
-    invitation_to_participate_in_research:
-      heading: Register to take part in a research session (opens in new tab)
-      body:
-        We are looking for people who are requesting records for Commissioned Officers.
-        Help us develop this part of the service and receive a voucher for your time.
     call_to_action: Request from the Ministry of Defence
   we_do_not_have_records_for_people_born_after:
     heading: We do not have records for people born after 1939

--- a/app/main/routes/routes.py
+++ b/app/main/routes/routes.py
@@ -254,7 +254,6 @@ def we_are_unlikely_to_hold_officer_records__army(form, state_machine):
         content=load_content(),
         form=form,
         mod_service_link=ExternalLinks.MOD_SERVICE_DECEASED_SERVICEPERSON,
-        invitation_to_participate_in_research_link=ExternalLinks.OFFICER_ENDPOINT_SURVEY,
     )
 
 
@@ -277,7 +276,6 @@ def we_are_unlikely_to_hold_officer_records__raf(form, state_machine):
         content=load_content(),
         form=form,
         mod_service_link=ExternalLinks.MOD_SERVICE_DECEASED_SERVICEPERSON,
-        invitation_to_participate_in_research_link=ExternalLinks.OFFICER_ENDPOINT_SURVEY,
     )
 
 

--- a/app/templates/main/we-are-unlikely-to-hold-army-officer-records.html
+++ b/app/templates/main/we-are-unlikely-to-hold-army-officer-records.html
@@ -32,10 +32,6 @@
             </a>
           </div>
         </form>
-        {{ researchInvitation(
-            content.pages.we_are_unlikely_to_hold_officer_records__army.invitation_to_participate_in_research.heading,
-            invitation_to_participate_in_research_link,
-            content.pages.we_are_unlikely_to_hold_officer_records__army.invitation_to_participate_in_research.body) }}
       </div>
     </div>
   </div>

--- a/app/templates/main/we-are-unlikely-to-hold-raf-officer-records.html
+++ b/app/templates/main/we-are-unlikely-to-hold-raf-officer-records.html
@@ -27,10 +27,6 @@
             </a>
           </div>
         </form>
-        {{ researchInvitation(
-            content.pages.we_are_unlikely_to_hold_officer_records__raf.invitation_to_participate_in_research.heading,
-            invitation_to_participate_in_research_link,
-            content.pages.we_are_unlikely_to_hold_officer_records__raf.invitation_to_participate_in_research.body) }}
       </div>
     </div>
   </div>

--- a/test/playwright/state-transitions/we-are-unlikely-to-hold-officer-records__army.spec.ts
+++ b/test/playwright/state-transitions/we-are-unlikely-to-hold-officer-records__army.spec.ts
@@ -20,16 +20,6 @@ test.describe("The variant of 'We are unlikely to hold this record' for Army Off
     );
   });
 
-  test("the link inviting users to participate in user research is correct", async ({
-    page,
-  }) => {
-    await checkExternalLink(
-      page,
-      "Register to take part in a research session (opens in new tab)",
-      "https://www.smartsurvey.co.uk/s/1KKGX5/",
-    );
-  });
-
   test("the 'Request from the Ministry of Defence' link is correct", async ({
     page,
   }) => {

--- a/test/playwright/state-transitions/we-are-unlikely-to-hold-officer-records__raf.spec.ts
+++ b/test/playwright/state-transitions/we-are-unlikely-to-hold-officer-records__raf.spec.ts
@@ -20,16 +20,6 @@ test.describe("The variant of 'We are unlikely to hold this record' for Army Off
     );
   });
 
-  test("the link inviting users to participate in user research is correct", async ({
-    page,
-  }) => {
-    await checkExternalLink(
-      page,
-      "Register to take part in a research session (opens in new tab)",
-      "https://www.smartsurvey.co.uk/s/1KKGX5/",
-    );
-  });
-
   test("the 'Request from the Ministry of Defence' link is correct", async ({
     page,
   }) => {


### PR DESCRIPTION
This pull request removes the invitation for users to participate in a research session about Commissioned Officer records from _both_ the Army and RAF "We are unlikely to hold this record" pages. This includes updates to the content, templates, and associated tests (but does not touch the Jinja2 macro we created for this purpose).

Content and UI changes:

* Removed the `invitation_to_participate_in_research` section and its associated heading and body from both the Army and RAF officer records pages in `content.yaml`.
* Deleted the `researchInvitation` macro call from the Army and RAF officer records HTML templates (as mentioned above, the macro still exists because we'll likely need it later)

Backend and constants cleanup:

* Removed the `OFFICER_ENDPOINT_SURVEY` link from `ExternalLinks` in `constants.py`, and associated usage in routes.

Testing updates:

* Deleted Playwright tests that checked for the presence and correctness of the research invitation link on both Army and RAF officer records pages.

> [!NOTE]
> The user journey diagram in Whimsical has also been updated to reflect this change.