### PR TITLE
FOI-314: Content and initial journey changes for PoD

### DIFF
--- a/app/content/content.yaml
+++ b/app/content/content.yaml
@@ -268,7 +268,7 @@ pages:
     subsequent_paragraphs:
       - Continue if the record you are looking for is contained in this list.
       - These records can only be requested from us using a Full record check, our Standard option is not available.
-    call_to_action: Request from the Ministry of Defence
+    call_to_action: Cancel this request
   we_do_not_have_records_for_people_born_after:
     heading: We do not have records for people born after 1939
     paragraphs:

--- a/app/content/content.yaml
+++ b/app/content/content.yaml
@@ -93,14 +93,13 @@ pages:
         - Their full date of birth
         - Your contact details so we can answer your request
     proof_of_death_requirement:
-      heading: Proof of death
+      heading: You may need a proof of death
       before_first_list:
         paragraphs:
           - |
-            If the person whose record you are looking for was born on or after 1 January [FIRST_BIRTH_YEAR_FOR_CLOSED_RECORDS] 
-            and is deceased, we require a digital copy of a proof of death. This is to protect 
-            any personal data in the record that might relate to a living person.
-          - "You will need to submit one of the following forms of evidence:"
+            If the person was born on or after 1 January [FIRST_BIRTH_YEAR_FOR_CLOSED_RECORDS] and is deceased, we will ask for 
+            a proof of death. This is to protect any personal data in the record that might relate to a living person.
+          - "You can submit one of the following forms of evidence: "
       before_second_list:
         paragraphs:
           - "The copy of proof of death must be:"
@@ -121,9 +120,9 @@ pages:
           If you do not submit a proof of death when required, it is 
           unlikely that we will be able to provide the record.
     important_information_that_will_help:
-      heading: Important information that will help our search
+      heading: Useful information that will help our search
       paragraphs:
-        - "To help us further, we also ask that you provide:"
+        - "To help us find the correct record, we will also ask optional questions on: "
       list_items:
         - The service person's service number
         - Military branch in which they served
@@ -258,15 +257,17 @@ pages:
     call_to_action: Request from the Ministry of Defence
   we_are_unlikely_to_hold_officer_records__army:
     heading: We are unlikely to hold this record yet
-    paragraphs:
-      - British Army Commissioned Officer records are currently being transferred to us. We may not hold the record you are looking for yet.
-      - We anticipate holding most Army Commissioned Officer records by December 2026.
-      - These records can only be requested from us using a Full record check, our Standard option is not available.
+    initial_paragraphs:
       - |
-        We recommend you check with the Ministry of Defence first, unless the record is contained in list the below:
+        British Army Commissioned Officer records are currently being transferred to us. We may not have the record you are looking for yet or are still processing it.
+        We recommend waiting until December 2026 to submit a request. By then, we will have received and processed most of these records and will be in a better position to search for it.
+      - "We do, however, hold records for:"
     list:
       - Grenadier Guards
       - Welsh Guards
+    subsequent_paragraphs:
+      - Continue if the record you are looking for is contained in this list.
+      - These records can only be requested from us using a Full record check, our Standard option is not available.
     call_to_action: Request from the Ministry of Defence
   we_do_not_have_records_for_people_born_after:
     heading: We do not have records for people born after 1939
@@ -397,7 +398,7 @@ pages:
           - term: Refunds
             description:
               - We will refund the page check fee (£9.92) if we do not hold the record.
-              - The search fee is not refundable.
+              - The search fee of £38.95 is not refundable.
     final_paragraphs:
       - We will send you a digital colour scan of the record by email. You can request a printed copy by post for an extra cost.
   your_order_type_other_and_dont_know_officers:
@@ -428,7 +429,7 @@ pages:
           - term: Refunds
             description:
               - We will refund the page check fee (£9.92) if we do not hold the record.
-              - The search fee is not refundable.
+              - The search fee of £38.95 is not refundable.
     final_paragraphs:
       - We will send you a digital colour scan of the record by email. You can request a printed copy by post for an extra cost.
   choose_your_order_type:
@@ -462,7 +463,7 @@ pages:
           - term: Refunds
             description:
               - We will refund the record copying fee (£3.30) if we do not hold the record.
-              - The search fee is not refundable.
+              - The search fee of £38.95 is not refundable.
     full_record_check:
       heading: Full record check
       paragraphs:
@@ -486,7 +487,7 @@ pages:
           - term: Refunds
             description:
               - We will refund the page check fee (£9.92) if we do not hold the record.
-              - The search fee is not refundable.
+              - The search fee of £38.95 is not refundable.
   your_order_summary:
     heading: Your order summary
     order_type_term: Order type

--- a/app/content/content.yaml
+++ b/app/content/content.yaml
@@ -260,6 +260,7 @@ pages:
     initial_paragraphs:
       - |
         British Army Commissioned Officer records are currently being transferred to us. We may not have the record you are looking for yet or are still processing it.
+      - |
         We recommend waiting until December 2026 to submit a request. By then, we will have received and processed most of these records and will be in a better position to search for it.
       - "We do, however, hold records for:"
     list:
@@ -376,7 +377,10 @@ pages:
       - |
         You are requesting a British Army Commissioned Officer record. These can only be requested with a Full record check, our Standard option is not available.
       - |
-        As British Army Commissioned Officer records are currently being transferred to us from the Ministry of Defence, we recommend waiting until December 2026 to submit your request. By then, we anticipate most will have been transferred to us.
+        British Army Commissioned Officer records are currently being transferred to us. We may not have the record you are looking for yet or are still processing it.
+      - |
+        We recommend waiting until December 2026 to submit a request. By then, we will have received and processed most of these records and will be in a better position 
+        to search for it.
     full_record_check:
       heading: Full record check
       paragraphs:
@@ -398,7 +402,7 @@ pages:
           - term: Refunds
             description:
               - We will refund the page check fee (£9.92) if we do not hold the record.
-              - The search fee of £38.95 is not refundable.
+              - The search fee of £38.95 is non-refundable.
     final_paragraphs:
       - We will send you a digital colour scan of the record by email. You can request a printed copy by post for an extra cost.
   your_order_type_other_and_dont_know_officers:
@@ -429,7 +433,7 @@ pages:
           - term: Refunds
             description:
               - We will refund the page check fee (£9.92) if we do not hold the record.
-              - The search fee of £38.95 is not refundable.
+              - The search fee of £38.95 is non-refundable.
     final_paragraphs:
       - We will send you a digital colour scan of the record by email. You can request a printed copy by post for an extra cost.
   choose_your_order_type:
@@ -463,7 +467,7 @@ pages:
           - term: Refunds
             description:
               - We will refund the record copying fee (£3.30) if we do not hold the record.
-              - The search fee of £38.95 is not refundable.
+              - The search fee of £38.95 is non-refundable.
     full_record_check:
       heading: Full record check
       paragraphs:
@@ -487,7 +491,7 @@ pages:
           - term: Refunds
             description:
               - We will refund the page check fee (£9.92) if we do not hold the record.
-              - The search fee of £38.95 is not refundable.
+              - The search fee of £38.95 is non-refundable.
   your_order_summary:
     heading: Your order summary
     order_type_term: Order type

--- a/app/main/routes/routes.py
+++ b/app/main/routes/routes.py
@@ -242,6 +242,7 @@ def we_do_not_have_royal_navy_service_records(form, state_machine):
     mappings={
         MultiPageFormRoutes.WHAT_WAS_THEIR_DATE_OF_BIRTH: MultiPageFormRoutes.WE_ARE_UNLIKELY_TO_HOLD_OFFICER_RECORDS__ARMY,
         MultiPageFormRoutes.YOUR_CONTACT_DETAILS: MultiPageFormRoutes.YOUR_ORDER_TYPE_BRITISH_ARMY_OFFICER,
+        MultiPageFormRoutes.ARE_YOU_SURE_YOU_WANT_TO_CANCEL: MultiPageFormRoutes.WE_ARE_UNLIKELY_TO_HOLD_OFFICER_RECORDS__ARMY,
     }
 )
 @with_state_machine

--- a/app/templates/main/we-are-unlikely-to-hold-army-officer-records.html
+++ b/app/templates/main/we-are-unlikely-to-hold-army-officer-records.html
@@ -29,10 +29,8 @@
           {{ form.csrf_token }}
           <div class="tna-button-group">
             {{ form.submit(params={'classes':'tna-button--plain'}) }}
-            <a href="{{ mod_service_link }}" target="_blank"
-               rel="noreferrer noopener" class="tna-button tna-button--accent">
-              {{ content.pages.we_are_unlikely_to_hold_officer_records__army.call_to_action }}
-            </a>
+            <a href="{{ url_for('main.are_you_sure_you_want_to_cancel') }}"
+               class="tna-button tna-button--accent">{{ content.pages.we_are_unlikely_to_hold_officer_records__army.call_to_action }}</a>
           </div>
         </form>
       </div>

--- a/app/templates/main/we-are-unlikely-to-hold-army-officer-records.html
+++ b/app/templates/main/we-are-unlikely-to-hold-army-officer-records.html
@@ -14,7 +14,7 @@
         class="tna-column tna-column--width-2-3 tna-column--width-5-6-medium tna-column--full-small tna-column--full-tiny">
         <h1
           class="tna-heading-xl tna-!--margin-top-m">{{ content.pages.we_are_unlikely_to_hold_officer_records__army.heading }}</h1>
-        {% for paragraph in content.pages.we_are_unlikely_to_hold_officer_records__army.paragraphs %}
+        {% for paragraph in content.pages.we_are_unlikely_to_hold_officer_records__army.initial_paragraphs %}
           <p>{{ paragraph }}</p>
         {% endfor %}
         <ul class="tna-ul" id="exceptions-list">
@@ -22,6 +22,9 @@
             <li>{{ rank }}</li>
           {% endfor %}
         </ul>
+        {% for paragraph in content.pages.we_are_unlikely_to_hold_officer_records__army.subsequent_paragraphs %}
+          <p>{{ paragraph }}</p>
+        {% endfor %}
         <form action="{{ url_for('main.we_are_unlikely_to_hold_officer_records__army') }}" method="post" novalidate>
           {{ form.csrf_token }}
           <div class="tna-button-group">

--- a/test/playwright/state-transitions/we-are-unlikely-to-hold-officer-records__army.spec.ts
+++ b/test/playwright/state-transitions/we-are-unlikely-to-hold-officer-records__army.spec.ts
@@ -2,7 +2,9 @@ import { test, expect } from "@playwright/test";
 import { Paths } from "../lib/constants";
 import {
   checkExternalLink,
+  checkInternalLink,
   clickBackLink,
+  clickCancelThisRequest,
   continueFromWeAreUnlikelyToHoldThisRecord,
 } from "../lib/step-functions";
 
@@ -17,16 +19,6 @@ test.describe("The variant of 'We are unlikely to hold this record' for Army Off
   }) => {
     await expect(page.locator("main")).toHaveText(
       /These records can only be requested from us using a Full record check/,
-    );
-  });
-
-  test("the 'Request from the Ministry of Defence' link is correct", async ({
-    page,
-  }) => {
-    await checkExternalLink(
-      page,
-      "Request from the Ministry of Defence",
-      "https://www.gov.uk/get-copy-military-records-of-service/apply-for-the-records-of-a-deceased-serviceperson",
     );
   });
 
@@ -64,6 +56,36 @@ test.describe("The variant of 'We are unlikely to hold this record' for Army Off
         page,
         Paths.WE_ARE_UNLIKELY_TO_HOLD_OFFICER_RECORDS__ARMY,
       );
+    });
+  });
+
+  test.describe("when clicking 'Cancel this request'", () => {
+    test("takes the user to the 'Are you sure you want to cancel?' page", async ({
+      page,
+    }) => {
+      await clickCancelThisRequest(page, "link");
+    });
+
+    test.describe("then", () => {
+      test("clicking 'Back' from 'Are you sure you want to cancel?' brings the user back", async ({
+        page,
+      }) => {
+        await clickCancelThisRequest(page, "link");
+        await clickBackLink(
+          page,
+          Paths.WE_ARE_UNLIKELY_TO_HOLD_OFFICER_RECORDS__ARMY,
+        );
+      });
+
+      test("clicking 'No' from 'Are you sure you want to cancel?' brings the user back", async ({
+        page,
+      }) => {
+        await clickCancelThisRequest(page, "link");
+        await page.getByRole("link", { name: "No", exact: true }).click();
+        await expect(page).toHaveURL(
+          Paths.WE_ARE_UNLIKELY_TO_HOLD_OFFICER_RECORDS__ARMY,
+        );
+      });
     });
   });
 });


### PR DESCRIPTION
This pull request introduces two changes related to amending the PoD requirement:

1. Content changes on "Before you start", "We are unlikely to hold this record" and all variants of the order type selection page (these changes are in the first commit)
2. Updating the British Army officer variant of "We are unlikely to hold this record yet" to replace the link to "Request from the Ministry of Defence" with a "Cancel this request" link (these changes are in the second commit)

**Test Suite Updates**

Playwright tests for "We are unlikely to hold this record yet" are updated to: remove the check for the external Ministry of Defence link; and add tests for the new "Cancel this request" flow, including navigation back from the "Are you sure you want to cancel?" page.